### PR TITLE
ENHANCEMENT: Rename BUILD_AS_STATIC build option to BUILD_MAGICXX_AS_STATIC, Fixes issue #28.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ [**ENHANCEMENT**] CMakeLists.txt, CMakePresets.json: Rename BUILD_AS_STATIC build option to BUILD_MAGICXX_AS_STATIC.
+
 + [**ENHANCEMENT**] CMakeLists.txt, CMakePresets.json, CONTRIBUTING.md, doc/CMakeLists.txt, scripts/commit_release.sh, scripts/generate_documentation.sh: Add support for building documentation from CMake and remove generate_documentation.sh script.
 
 ## [v5.6.3] - 16-03-2025

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project(magicxx
     LANGUAGES C CXX
 )
 
-option(BUILD_AS_STATIC "Build as static." OFF)
+option(BUILD_MAGICXX_AS_STATIC "Build as static." OFF)
 option(BUILD_MAGICXX_TESTS "Build the tests." OFF)
 option(BUILD_MAGICXX_EXAMPLES "Build the examples." OFF)
 option(BUILD_MAGICXX_DOCUMENTATION_ONLY "Build only the documentation." OFF)
@@ -20,7 +20,7 @@ if (BUILD_MAGICXX_DOCUMENTATION_ONLY)
     return()
 endif()
 
-if(BUILD_AS_STATIC)
+if(BUILD_MAGICXX_AS_STATIC)
     set(LIBRARY_TYPE STATIC)
 else()
     set(LIBRARY_TYPE SHARED)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -85,7 +85,7 @@
         {
             "name": "static-config",
             "cacheVariables": {
-                "BUILD_AS_STATIC": "ON"
+                "BUILD_MAGICXX_AS_STATIC": "ON"
             },
             "hidden": true
         },


### PR DESCRIPTION
## Description

Rename BUILD_AS_STATIC build option to BUILD_MAGICXX_AS_STATIC to avoid any potential confusion or accidental setting of a generally named option.

Fixes issue #28 .

...

## Checklist

+ [x] I have read the [CONTRIBUTING.md](https://github.com/oguztoraman/libmagicxx/blob/main/CONTRIBUTING.md).
+ [x] Changes follow the project's coding style.
+ [x] Changes pass all new and existing unit tests.
+ [x] Changes are documented with Doxygen.
+ [x] Related documentation is updated.

### Title Format Guidelines

+ For bug fixes: `BUGFIX: Brief Description, Fixes issue #????.`
+ For documentation changes: `DOCUMENTATION: Brief Description, Fixes issue #????.`
+ For enhancements: `ENHANCEMENT: Brief Description, Fixes issue #????.`
