### PR TITLE
BUGFIX: Magicxx: Do not throw exceptions while constructing std::filesystem::recursive_directory_iterator in a noexcept function, Fixes issue #92.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ [**BUGFIX**] include/magicxx/magic.hpp: Magicxx: Do not throw exceptions while constructing std::filesystem::recursive_directory_iterator in a noexcept function.
+
 + [**DOCUMENTATION**] CONTRIBUTING.md, README.md: Docs: Update CONTRIBUTING.md and README.md to include CMake options and package variables.
 
 + [**ENHANCEMENT**] cmake/install.cmake, cmake/magicxxConfig.cmake.in, cmake/options.cmake, cmake/targets.cmake, examples/CMakeLists.txt, scripts/workflows.sh, tests/CMakeLists.txt: CMake: Add options to build shared and static libraries independently.

--- a/include/magicxx/magic.hpp
+++ b/include/magicxx/magic.hpp
@@ -344,8 +344,13 @@ public:
             directory_options::follow_directory_symlink
     ) const noexcept
     {
+        std::error_code error_code{};
         return identify_files_impl(
-            std::filesystem::recursive_directory_iterator{directory, option},
+            std::filesystem::recursive_directory_iterator{
+                directory,
+                option,
+                error_code
+            },
             std::nothrow
         );
     }


### PR DESCRIPTION
## Description

 Magicxx: Do not throw exceptions while constructing std::filesystem::recursive_directory_iterator in a noexcept function.

Fixes issue #92.

...

## Checklist

+ [x] I have read the [CONTRIBUTING.md](https://github.com/oguztoraman/libmagicxx/blob/main/CONTRIBUTING.md).
+ [x] Changes follow the project's coding style.
+ [x] Changes pass all new and existing unit tests.
+ [x] Changes are documented with Doxygen.
+ [x] Related documentation is updated.

### Title Format Guidelines

+ For bug fixes: `BUGFIX: Brief Description, Fixes issue #????.`
+ For documentation changes: `DOCUMENTATION: Brief Description, Fixes issue #????.`
+ For enhancements: `ENHANCEMENT: Brief Description, Fixes issue #????.`
+ For code quality improvements: `QUALITY: Brief Description, Fixes issue #????.`
