### PR TITLE
BUGFIX: Magicxx: Add magic_database_not_loaded exception and update identify_file functions to handle database loading state, Fixes issue #97.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ [**BUGFIX**] include/magicxx/magic_exception.hpp, include/magicxx/magic.hpp, sources/magic.cpp, tests/magic_identify_file_test.cpp: Magicxx: Add magic_database_not_loaded exception and update identify_file functions to handle database loading state.
+
 + [**DOCUMENTATION**] README.md: Docs: Add C++ standard badge to README.md.
 
 + [**QUALITY**] tests/magic_load_database_file_test.cpp: Tests: Refactor magic_load_database_file_test with using test fixture.

--- a/include/magicxx/magic.hpp
+++ b/include/magicxx/magic.hpp
@@ -287,9 +287,10 @@ public:
      *
      * @returns The type of the file as a string.
      *
-     * @throws magic_is_closed      if magic is closed.
-     * @throws empty_path           if the path of the file is empty.
-     * @throws magic_file_error     if identifying the type of the file fails.
+     * @throws magic_is_closed              if magic is closed.
+     * @throws magic_database_not_loaded    if the magic database is not loaded.
+     * @throws empty_path                   if the path of the file is empty.
+     * @throws magic_file_error             if identifying the type of the file fails.
      */
     [[nodiscard]] file_type_t identify_file(const std::filesystem::path& path
     ) const;
@@ -314,9 +315,10 @@ public:
      *
      * @returns The types of each file as a map.
      *
-     * @throws magic_is_closed      if magic is closed.
-     * @throws empty_path           if the path of the file is empty.
-     * @throws magic_file_error     if identifying the type of the file fails.
+     * @throws magic_is_closed              if magic is closed.
+     * @throws magic_database_not_loaded    if the magic database is not loaded.
+     * @throws empty_path                   if the path of the file is empty.
+     * @throws magic_file_error             if identifying the type of the file fails.
      */
     [[nodiscard]] types_of_files_t identify_files(
         const std::filesystem::path&       directory,
@@ -362,9 +364,10 @@ public:
      *
      * @returns The types of each file as a map.
      *
-     * @throws magic_is_closed      if magic is closed.
-     * @throws empty_path           if the path of the file is empty.
-     * @throws magic_file_error     if identifying the type of the file fails.
+     * @throws magic_is_closed              if magic is closed.
+     * @throws magic_database_not_loaded    if the magic database is not loaded.
+     * @throws empty_path                   if the path of the file is empty.
+     * @throws magic_file_error             if identifying the type of the file fails.
      */
     [[nodiscard]] types_of_files_t identify_files(
         const file_concepts::file_container auto& files

--- a/include/magicxx/magic_exception.hpp
+++ b/include/magicxx/magic_exception.hpp
@@ -75,6 +75,13 @@ public:
     { }
 };
 
+class magic_database_not_loaded final : public magic_exception {
+public:
+    magic_database_not_loaded()
+      : magic_exception{"magic database is not loaded."}
+    { }
+};
+
 class magic_file_error final : public magic_exception {
 public:
     magic_file_error(const std::string& error, const std::string& file_path)

--- a/tests/magic_identify_file_test.cpp
+++ b/tests/magic_identify_file_test.cpp
@@ -31,6 +31,22 @@ TEST(magic_identify_file_test, opened_magic_identify_empty_path)
     EXPECT_THROW([[maybe_unused]] auto _ = m.identify_file({}), empty_path);
 }
 
+TEST(magic_identify_file_test, opened_magic_database_not_loaded)
+{
+    magic m;
+    m.open(magic::flags::mime);
+    auto expected_file_type = m.identify_file(
+        DEFAULT_DATABASE_FILE,
+        std::nothrow
+    );
+    EXPECT_FALSE(expected_file_type.has_value());
+    EXPECT_EQ(expected_file_type.error(), "magic database is not loaded.");
+    EXPECT_THROW(
+        [[maybe_unused]] auto _ = m.identify_file(DEFAULT_DATABASE_FILE),
+        magic_database_not_loaded
+    );
+}
+
 TEST(magic_identify_file_test, opened_magic_identify_default_database)
 {
     magic m{magic::flags::mime, DEFAULT_DATABASE_FILE};


### PR DESCRIPTION
## Description

Magicxx: Add magic_database_not_loaded exception and update identify_file functions to handle database loading state.

Fixes issue #97.

...

## Checklist

+ [x] I have read the [CONTRIBUTING.md](https://github.com/oguztoraman/libmagicxx/blob/main/CONTRIBUTING.md).
+ [x] Changes follow the project's coding style.
+ [x] Changes pass all new and existing unit tests.
+ [x] Changes are documented with Doxygen.
+ [x] Related documentation is updated.

### Title Format Guidelines

+ For bug fixes: `BUGFIX: Brief Description, Fixes issue #????.`
+ For documentation changes: `DOCUMENTATION: Brief Description, Fixes issue #????.`
+ For enhancements: `ENHANCEMENT: Brief Description, Fixes issue #????.`
+ For code quality improvements: `QUALITY: Brief Description, Fixes issue #????.`
