### PR TITLE
ENHANCEMENT: Magicxx: API change – Add is_valid() to check if instance is valid for identification (open and database loaded); Make operator bool() a shortcut for is_valid(), Fixes issue #101.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ [**ENHANCEMENT**] include/magicxx/magic.hpp, sources/magic.cpp, tests/*: Magicxx: API change – Add is_valid() to check if instance is valid for identification (open and database loaded); Make operator bool() a shortcut for is_valid().
+
 + [**ENHANCEMENT**] external/googletest: Tests: Update googletest version to v1.17.0.
 
 + [**BUGFIX**] include/magicxx/magic_exception.hpp, include/magicxx/magic.hpp, sources/magic.cpp, tests/magic_identify_file_test.cpp: Magicxx: Add magic_database_not_loaded exception and update identify_file functions to handle database loading state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Next Release
 
-+ [**ENHANCEMENT**] include/magicxx/magic.hpp, sources/magic.cpp, tests/*: Magicxx: API change – Add is_valid() to check if instance is valid for identification (open and database loaded); Make operator bool() a shortcut for is_valid().
++ [**ENHANCEMENT**] include/magicxx/magic.hpp, sources/magic.cpp, tests/*, examples/*: Magicxx: API change – Add is_valid() to check if instance is valid for identification (open and database loaded); Make operator bool() a shortcut for is_valid().
 
 + [**ENHANCEMENT**] external/googletest: Tests: Update googletest version to v1.17.0.
 

--- a/examples/magic_examples.cpp
+++ b/examples/magic_examples.cpp
@@ -35,7 +35,11 @@ void example_load_database()
 void example_identify_file()
 {
     magic m{magic::flags::mime, magic::default_database_file};
-    auto  result = m.identify_file(magic::default_database_file);
+    if (!m.is_valid()) {
+        std::println(std::cerr, "Magic is not valid.");
+        return;
+    }
+    auto result = m.identify_file(magic::default_database_file);
     std::println(std::cout, "File type: {}", result);
 }
 

--- a/include/magicxx/magic.hpp
+++ b/include/magicxx/magic.hpp
@@ -22,9 +22,10 @@ namespace recognition {
  *
  * @brief The magic class provides a C++ wrapper over the Magic Number Recognition Library.
  *
- * @note  The magic class is used to identify the type of a file, if the following steps have been completed;
- *        1. magic must be opened.
- *        2. A magic database file must be loaded.
+ * @note  To use the magic class for file type identification, ensure the following:
+ *        1. The magic instance must be opened.
+ *        2. A magic database file must be successfully loaded.
+ *        Only after these steps is the instance considered valid for identifying file types.
  */
 class magic {
 public:
@@ -137,6 +138,9 @@ public:
 
     /**
      * @brief Construct magic without opening it.
+     * 
+     * @note This magic is not valid for identifying file types
+     *       until it is opened and a magic database file is loaded.
      */
     magic() noexcept;
 
@@ -177,7 +181,9 @@ public:
     /**
      * @brief Move construct magic.
      *
-     * @note other is valid as a default constructed magic.
+     * @note After move construction, the moved-from object (other) is closed.
+     *       It cannot be used for identifying file types until 
+     *       it is reopened and a magic database file is loaded.
      */
     magic(magic&& other) noexcept;
 
@@ -189,7 +195,9 @@ public:
     /**
      * @brief Move assign to this magic.
      *
-     * @note other is valid as a default constructed magic.
+     * @note After move construction, the moved-from object (other) is closed.
+     *       It cannot be used for identifying file types until
+     *       it is reopened and a magic database file is loaded.
      */
     magic& operator=(magic&& other) noexcept;
 
@@ -204,9 +212,12 @@ public:
     ~magic();
 
     /**
-     * @brief Used for testing whether magic is open or closed.
+     * @brief Used for testing whether magic is valid
+     *        for identifying file types or not.
      *
-     * @returns True if magic is open, false otherwise.
+     * @returns True if the magic is valid, i.e.,
+     *          it is open and a magic database file is loaded;
+     *          false otherwise.
      */
     [[nodiscard]] operator bool() const noexcept;
 
@@ -225,7 +236,8 @@ public:
     /**
      * @brief Close magic.
      *
-     * @note magic is valid as a default constructed magic.
+     * @note magic cannot be used for identifying file types until
+     *       it is reopened and a magic database file is loaded.
      */
     void close() noexcept;
 
@@ -397,6 +409,16 @@ public:
      * @returns True if magic is open, false otherwise.
      */
     [[nodiscard]] bool is_open() const noexcept;
+
+    /**
+     * @brief Used for testing whether magic is valid
+     *        for identifying file types or not.
+     *
+     * @returns True if the magic is valid, i.e.,
+     *          it is open and a magic database file is loaded;
+     *          false otherwise.
+     */
+    [[nodiscard]] bool is_valid() const noexcept;
 
     /**
      * @brief Load a magic database file.

--- a/sources/magic.cpp
+++ b/sources/magic.cpp
@@ -158,6 +158,11 @@ public:
         return m_cookie != nullptr;
     }
 
+    [[nodiscard]] bool is_valid() const noexcept
+    {
+        return is_open() && m_is_database_loaded;
+    }
+
     void load_database_file(const std::filesystem::path& database_file)
     {
         throw_exception_on_failure<magic_is_closed>(is_open());
@@ -561,7 +566,7 @@ magic::~magic() = default;
 
 [[nodiscard]] magic::operator bool() const noexcept
 {
-    return is_open();
+    return is_valid();
 }
 
 bool magic::check(const std::filesystem::path& database_file) const noexcept
@@ -618,6 +623,11 @@ bool magic::compile(const std::filesystem::path& database_file) const noexcept
 [[nodiscard]] bool magic::is_open() const noexcept
 {
     return m_impl->is_open();
+}
+
+[[nodiscard]] bool magic::is_valid() const noexcept
+{
+    return m_impl->is_valid();
 }
 
 void magic::load_database_file(const std::filesystem::path& database_file)

--- a/tests/magic_identify_file_test.cpp
+++ b/tests/magic_identify_file_test.cpp
@@ -14,6 +14,8 @@ TEST(magic_identify_file_test, closed_magic_identify_file)
         magic::default_database_file,
         std::nothrow
     );
+    EXPECT_FALSE(m);
+    EXPECT_FALSE(m.is_valid());
     EXPECT_FALSE(expected_file_type.has_value());
     EXPECT_EQ(expected_file_type.error(), "magic is closed.");
     EXPECT_THROW(
@@ -25,7 +27,9 @@ TEST(magic_identify_file_test, closed_magic_identify_file)
 TEST(magic_identify_file_test, opened_magic_identify_empty_path)
 {
     magic m{magic::flags::mime, DEFAULT_DATABASE_FILE};
-    auto  expected_file_type = m.identify_file({}, std::nothrow);
+    EXPECT_TRUE(m);
+    EXPECT_TRUE(m.is_valid());
+    auto expected_file_type = m.identify_file({}, std::nothrow);
     EXPECT_FALSE(expected_file_type.has_value());
     EXPECT_EQ(expected_file_type.error(), "path is empty.");
     EXPECT_THROW([[maybe_unused]] auto _ = m.identify_file({}), empty_path);
@@ -35,6 +39,8 @@ TEST(magic_identify_file_test, opened_magic_database_not_loaded)
 {
     magic m;
     m.open(magic::flags::mime);
+    EXPECT_FALSE(m);
+    EXPECT_FALSE(m.is_valid());
     auto expected_file_type = m.identify_file(
         DEFAULT_DATABASE_FILE,
         std::nothrow
@@ -50,6 +56,8 @@ TEST(magic_identify_file_test, opened_magic_database_not_loaded)
 TEST(magic_identify_file_test, opened_magic_identify_default_database)
 {
     magic m{magic::flags::mime, DEFAULT_DATABASE_FILE};
+    EXPECT_TRUE(m);
+    EXPECT_TRUE(m.is_valid());
     EXPECT_EQ(
         m.identify_file(DEFAULT_DATABASE_FILE),
         "text/x-file; charset=us-ascii"

--- a/tests/magic_load_database_file_test.cpp
+++ b/tests/magic_load_database_file_test.cpp
@@ -57,5 +57,7 @@ TEST_F(magic_load_database_file_test, opened_magic_load_invalid_database)
 
 TEST_F(magic_load_database_file_test, opened_magic_load_default_database)
 {
+    EXPECT_FALSE(opened_magic.is_valid());
     opened_magic.load_database_file(DEFAULT_DATABASE_FILE);
+    EXPECT_TRUE(opened_magic.is_valid());
 }

--- a/tests/magic_open_close_test.cpp
+++ b/tests/magic_open_close_test.cpp
@@ -12,6 +12,7 @@ TEST(magic_open_close_test, closed_magic_is_open)
     magic m;
     EXPECT_FALSE(m);
     EXPECT_FALSE(m.is_open());
+    EXPECT_FALSE(m.is_valid());
 }
 
 TEST(magic_open_close_test, closed_magic_close)
@@ -20,14 +21,16 @@ TEST(magic_open_close_test, closed_magic_close)
     m.close();
     EXPECT_FALSE(m);
     EXPECT_FALSE(m.is_open());
+    EXPECT_FALSE(m.is_valid());
 }
 
 TEST(magic_open_close_test, opened_magic_is_open)
 {
     magic m;
     m.open(magic::flags::mime);
-    EXPECT_TRUE(m);
+    EXPECT_FALSE(m);
     EXPECT_TRUE(m.is_open());
+    EXPECT_FALSE(m.is_valid());
 }
 
 TEST(magic_open_close_test, opened_magic_close)
@@ -37,6 +40,7 @@ TEST(magic_open_close_test, opened_magic_close)
     m.close();
     EXPECT_FALSE(m);
     EXPECT_FALSE(m.is_open());
+    EXPECT_FALSE(m.is_valid());
 }
 
 TEST(magic_open_close_test, opened_magic_open_twice)
@@ -44,8 +48,9 @@ TEST(magic_open_close_test, opened_magic_open_twice)
     magic m;
     m.open(magic::flags::mime);
     m.open(magic::flags::mime_type);
-    EXPECT_TRUE(m);
+    EXPECT_FALSE(m);
     EXPECT_TRUE(m.is_open());
+    EXPECT_FALSE(m.is_valid());
 }
 
 TEST(magic_open_close_test, opened_magic_close_twice)
@@ -56,6 +61,7 @@ TEST(magic_open_close_test, opened_magic_close_twice)
     m.close();
     EXPECT_FALSE(m);
     EXPECT_FALSE(m.is_open());
+    EXPECT_FALSE(m.is_valid());
 }
 
 TEST(magic_open_close_test, open_magic_using_flags_container)
@@ -65,6 +71,7 @@ TEST(magic_open_close_test, open_magic_using_flags_container)
         magic::flags::mime,
         magic::flags::continue_search
     });
-    EXPECT_TRUE(m);
+    EXPECT_FALSE(m);
     EXPECT_TRUE(m.is_open());
+    EXPECT_FALSE(m.is_valid());
 }

--- a/tests/magic_special_members_test.cpp
+++ b/tests/magic_special_members_test.cpp
@@ -13,6 +13,8 @@ TEST(magic_special_members_test, move_construct_magic_from_closed_magic)
     auto  m{std::move(other)};
     EXPECT_FALSE(m.is_open());
     EXPECT_FALSE(other.is_open());
+    EXPECT_FALSE(m.is_valid());
+    EXPECT_FALSE(other.is_valid());
 }
 
 TEST(magic_special_members_test, move_construct_magic_from_opened_magic)
@@ -22,6 +24,8 @@ TEST(magic_special_members_test, move_construct_magic_from_opened_magic)
     auto m{std::move(other)};
     EXPECT_TRUE(m.is_open());
     EXPECT_FALSE(other.is_open());
+    EXPECT_FALSE(m.is_valid());
+    EXPECT_FALSE(other.is_valid());
 }
 
 TEST(magic_special_members_test, move_assign_magic_from_closed_magic)
@@ -30,6 +34,8 @@ TEST(magic_special_members_test, move_assign_magic_from_closed_magic)
     auto  m = std::move(other);
     EXPECT_FALSE(m.is_open());
     EXPECT_FALSE(other.is_open());
+    EXPECT_FALSE(m.is_valid());
+    EXPECT_FALSE(other.is_valid());
 }
 
 TEST(magic_special_members_test, move_assign_magic_from_opened_magic)
@@ -39,4 +45,6 @@ TEST(magic_special_members_test, move_assign_magic_from_opened_magic)
     auto m = std::move(other);
     EXPECT_TRUE(m.is_open());
     EXPECT_FALSE(other.is_open());
+    EXPECT_FALSE(m.is_valid());
+    EXPECT_FALSE(other.is_valid());
 }


### PR DESCRIPTION
## Description

### Magicxx: API change 
+  Add is_valid() to check if instance is valid for identification (open and database loaded)
+ Make operator bool() a shortcut for is_valid()

Fixes issue #101.

...

## Checklist

+ [x] I have read the [CONTRIBUTING.md](https://github.com/oguztoraman/libmagicxx/blob/main/CONTRIBUTING.md).
+ [x] Changes follow the project's coding style.
+ [x] Changes pass all new and existing unit tests.
+ [x] Changes are documented with Doxygen.
+ [x] Related documentation is updated.

### Title Format Guidelines

+ For bug fixes: `BUGFIX: Brief Description, Fixes issue #????.`
+ For documentation changes: `DOCUMENTATION: Brief Description, Fixes issue #????.`
+ For enhancements: `ENHANCEMENT: Brief Description, Fixes issue #????.`
+ For code quality improvements: `QUALITY: Brief Description, Fixes issue #????.`
