### PR TITLE
QUALITY: Magicxx: Move implementation of identify_files functions from header to source file, Fixes issue #102.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ [**QUALITY**] include/magicxx/magic.hpp, sources/magic.cpp: Magicxx: Move implementation of identify_files functions from header to source file.
+
 + [**ENHANCEMENT**] include/magicxx/magic.hpp, sources/magic.cpp, tests/*, examples/*: Magicxx: API change – Add is_valid() to check if instance is valid for identification (open and database loaded); Make operator bool() a shortcut for is_valid().
 
 + [**ENHANCEMENT**] external/googletest: Tests: Update googletest version to v1.17.0.

--- a/include/magicxx/magic.hpp
+++ b/include/magicxx/magic.hpp
@@ -336,12 +336,7 @@ public:
         const std::filesystem::path&       directory,
         std::filesystem::directory_options option = std::filesystem::
             directory_options::follow_directory_symlink
-    ) const
-    {
-        return identify_files_impl(
-            std::filesystem::recursive_directory_iterator{directory, option}
-        );
-    }
+    ) const;
 
     /**
      * @brief Identify the types of all files in a directory, noexcept version.
@@ -356,18 +351,7 @@ public:
         std::nothrow_t,
         std::filesystem::directory_options option = std::filesystem::
             directory_options::follow_directory_symlink
-    ) const noexcept
-    {
-        std::error_code error_code{};
-        return identify_files_impl(
-            std::filesystem::recursive_directory_iterator{
-                directory,
-                option,
-                error_code
-            },
-            std::nothrow
-        );
-    }
+    ) const noexcept;
 
     /**
      * @brief Identify the types of files.
@@ -383,10 +367,7 @@ public:
      */
     [[nodiscard]] types_of_files_t identify_files(
         const file_concepts::file_container auto& files
-    ) const
-    {
-        return identify_files_impl(files);
-    }
+    ) const;
 
     /**
      * @brief Identify the types of files, noexcept version.
@@ -398,10 +379,7 @@ public:
     [[nodiscard]] expected_types_of_files_t identify_files(
         const file_concepts::file_container auto& files,
         std::nothrow_t
-    ) const noexcept
-    {
-        return identify_files_impl(files, std::nothrow);
-    }
+    ) const noexcept;
 
     /**
      * @brief Used for testing whether magic is open or closed.
@@ -502,29 +480,6 @@ public:
 private:
     class magic_private;
     std::unique_ptr<magic_private> m_impl;
-
-    [[nodiscard]] types_of_files_t identify_files_impl(
-        const std::ranges::range auto& files
-    ) const
-    {
-        types_of_files_t types_of_files;
-        std::ranges::for_each(files, [&](const std::filesystem::path& file) {
-            types_of_files[file] = identify_file(file);
-        });
-        return types_of_files;
-    }
-
-    [[nodiscard]] expected_types_of_files_t identify_files_impl(
-        const std::ranges::range auto& files,
-        std::nothrow_t
-    ) const noexcept
-    {
-        expected_types_of_files_t expected_types_of_files;
-        std::ranges::for_each(files, [&](const std::filesystem::path& file) {
-            expected_types_of_files[file] = identify_file(file, std::nothrow);
-        });
-        return expected_types_of_files;
-    }
 
     friend std::string to_string(flags);
     friend std::string to_string(parameters);

--- a/sources/magic.cpp
+++ b/sources/magic.cpp
@@ -153,6 +153,29 @@ public:
         return {type_cstr};
     }
 
+    [[nodiscard]] types_of_files_t identify_files(
+        const std::ranges::range auto& files
+    ) const
+    {
+        types_of_files_t types_of_files;
+        std::ranges::for_each(files, [&](const std::filesystem::path& file) {
+            types_of_files[file] = identify_file(file);
+        });
+        return types_of_files;
+    }
+
+    [[nodiscard]] expected_types_of_files_t identify_files(
+        const std::ranges::range auto& files,
+        std::nothrow_t
+    ) const noexcept
+    {
+        expected_types_of_files_t expected_types_of_files;
+        std::ranges::for_each(files, [&](const std::filesystem::path& file) {
+            expected_types_of_files[file] = identify_file(file, std::nothrow);
+        });
+        return expected_types_of_files;
+    }
+
     [[nodiscard]] bool is_open() const noexcept
     {
         return m_cookie != nullptr;
@@ -618,6 +641,48 @@ bool magic::compile(const std::filesystem::path& database_file) const noexcept
 ) const noexcept
 {
     return m_impl->identify_file(path, std::nothrow);
+}
+
+[[nodiscard]] magic::types_of_files_t magic::identify_files(
+    const std::filesystem::path&       directory,
+    std::filesystem::directory_options option
+) const
+{
+    return m_impl->identify_files(
+        std::filesystem::recursive_directory_iterator{directory, option}
+    );
+}
+
+[[nodiscard]] magic::expected_types_of_files_t magic::identify_files(
+    const std::filesystem::path& directory,
+    std::nothrow_t,
+    std::filesystem::directory_options option
+) const noexcept
+{
+    std::error_code error_code{};
+    return m_impl->identify_files(
+        std::filesystem::recursive_directory_iterator{
+            directory,
+            option,
+            error_code
+        },
+        std::nothrow
+    );
+}
+
+[[nodiscard]] magic::types_of_files_t magic::identify_files(
+    const file_concepts::file_container auto& files
+) const
+{
+    return m_impl->identify_files(files);
+}
+
+[[nodiscard]] magic::expected_types_of_files_t magic::identify_files(
+    const file_concepts::file_container auto& files,
+    std::nothrow_t
+) const noexcept
+{
+    return m_impl->identify_files(files, std::nothrow);
 }
 
 [[nodiscard]] bool magic::is_open() const noexcept


### PR DESCRIPTION
## Description

Magicxx: Move implementation of identify_files functions from header to source file.

Fixes issue #102.

...

## Checklist

+ [x] I have read the [CONTRIBUTING.md](https://github.com/oguztoraman/libmagicxx/blob/main/CONTRIBUTING.md).
+ [x] Changes follow the project's coding style.
+ [x] Changes pass all new and existing unit tests.
+ [x] Changes are documented with Doxygen.
+ [x] Related documentation is updated.

### Title Format Guidelines

+ For bug fixes: `BUGFIX: Brief Description, Fixes issue #????.`
+ For documentation changes: `DOCUMENTATION: Brief Description, Fixes issue #????.`
+ For enhancements: `ENHANCEMENT: Brief Description, Fixes issue #????.`
+ For code quality improvements: `QUALITY: Brief Description, Fixes issue #????.`
