### PR TITLE
ENHANCEMENT; Magicxx: API change - Rename magic_set_param_error and magic_file_error, Fixes issue #113.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ [**ENHANCEMENT**] include/magicxx/magic_exception.hpp, include/magicxx/magic.hpp, sources/magic.cpp; Magicxx: API change - Rename magic_set_param_error to magic_set_parameter_error for consistency and clarity in exception handling.
+
 + [**ENHANCEMENT**] include/magicxx/magic_exception.hpp, include/magicxx/magic.hpp, sources/magic.cpp, tests/magic_load_database_file_test.cpp; Magicxx: API change - Replace invalid_path exception with path_is_not_regular_file for better clarity in error handling.
 
 + [**ENHANCEMENT**] include/magicxx/magic_exception.hpp, include/magicxx/magic.hpp, sources/magic.cpp; Magicxx: API change - Add path_does_not_exist exception and enhance error handling for file paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ [**ENHANCEMENT**] include/magicxx/magic_exception.hpp, include/magicxx/magic.hpp, sources/magic.cpp; Magicxx: API change - Rename magic_file_error to magic_identify_file_error for consistency and clarity in exception handling.
+
 + [**ENHANCEMENT**] include/magicxx/magic_exception.hpp, include/magicxx/magic.hpp, sources/magic.cpp; Magicxx: API change - Rename magic_set_param_error to magic_set_parameter_error for consistency and clarity in exception handling.
 
 + [**ENHANCEMENT**] include/magicxx/magic_exception.hpp, include/magicxx/magic.hpp, sources/magic.cpp, tests/magic_load_database_file_test.cpp; Magicxx: API change - Replace invalid_path exception with path_is_not_regular_file for better clarity in error handling.

--- a/include/magicxx/magic.hpp
+++ b/include/magicxx/magic.hpp
@@ -610,11 +610,11 @@ public:
     /**
      * @brief Set the value of a parameter of magic.
      *
-     * @param[in] parameter           One of the parameters enum.
-     * @param[in] value               The value of the parameter.
+     * @param[in] parameter                 One of the parameters enum.
+     * @param[in] value                     The value of the parameter.
      *
-     * @throws magic_is_closed        if magic is closed.
-     * @throws magic_set_param_error  if setting the parameter of magic fails.
+     * @throws magic_is_closed              if magic is closed.
+     * @throws magic_set_parameter_error    if setting the parameter of magic fails.
      */
     void set_parameter(parameters parameter, std::size_t value);
 
@@ -636,10 +636,10 @@ public:
     /**
      * @brief Set the values of the parameters of magic.
      *
-     * @param[in] parameters          Parameters with corresponding values.
+     * @param[in] parameters                Parameters with corresponding values.
      *
-     * @throws magic_is_closed        if magic is closed.
-     * @throws magic_set_param_error  if setting the parameter of magic fails.
+     * @throws magic_is_closed              if magic is closed.
+     * @throws magic_set_parameter_error    if setting the parameter of magic fails.
      */
     void set_parameters(const parameter_value_map_t& parameters);
 

--- a/include/magicxx/magic.hpp
+++ b/include/magicxx/magic.hpp
@@ -372,7 +372,7 @@ public:
      * @throws magic_database_not_loaded    if the magic database is not loaded.
      * @throws empty_path                   if the path of the file is empty.
      * @throws path_does_not_exist          if the path of the file does not exist.
-     * @throws magic_file_error             if identifying the type of the file fails.
+     * @throws magic_identify_file_error    if identifying the type of the file fails.
      */
     [[nodiscard]] file_type_t identify_file(const std::filesystem::path& path
     ) const;
@@ -402,7 +402,7 @@ public:
      * @throws magic_database_not_loaded    if the magic database is not loaded.
      * @throws empty_path                   if the path of the file is empty.
      * @throws path_does_not_exist          if the path of the file does not exist.
-     * @throws magic_file_error             if identifying the type of the file fails.
+     * @throws magic_identify_file_error    if identifying the type of the file fails.
      */
     [[nodiscard]] types_of_files_t identify_files(
         const std::filesystem::path&       directory,
@@ -437,7 +437,7 @@ public:
      * @throws magic_database_not_loaded    if the magic database is not loaded.
      * @throws empty_path                   if the path of the file is empty.
      * @throws path_does_not_exist          if the path of the file does not exist.
-     * @throws magic_file_error             if identifying the type of the file fails.
+     * @throws magic_identify_file_error    if identifying the type of the file fails.
      */
     [[nodiscard]] types_of_files_t identify_files(
         const file_concepts::file_container auto& files

--- a/include/magicxx/magic_exception.hpp
+++ b/include/magicxx/magic_exception.hpp
@@ -111,10 +111,28 @@ public:
     { }
 };
 
-class magic_file_error final : public magic_exception {
+/**
+ * @class magic_identify_file_error
+ *
+ * @brief Exception thrown when magic::identify_file(s) fails.
+ */
+class magic_identify_file_error final : public magic_exception {
 public:
-    magic_file_error(const std::string& error, const std::string& file_path)
-      : magic_exception{std::format("magic_file({})", file_path), error}
+    /**
+     * @brief Construct magic_identify_file_error with an error message,
+     *        and the path of the file.
+     *
+     * @param[in] error_message         The description of the error.
+     * @param[in] file_path             The path of the file.
+     */
+    magic_identify_file_error(
+        const std::string& error_message,
+        const std::string& file_path
+    )
+      : magic_exception{
+            std::format("magic_identify_file({})", file_path),
+            error_message
+        }
     { }
 };
 

--- a/include/magicxx/magic_exception.hpp
+++ b/include/magicxx/magic_exception.hpp
@@ -140,7 +140,7 @@ public:
      *        the name of the parameter and its value.
      *
      * @param[in] error_message         The description of the error.
-     * @param[in] parameter_name        The names of the parameter.
+     * @param[in] parameter_name        The name of the parameter.
      * @param[in] value                 The value of the parameter.
      */
     magic_set_parameter_error(

--- a/include/magicxx/magic_exception.hpp
+++ b/include/magicxx/magic_exception.hpp
@@ -128,16 +128,29 @@ public:
     { }
 };
 
-class magic_set_param_error final : public magic_exception {
+/**
+ * @class magic_set_parameter_error
+ *
+ * @brief Exception thrown when magic::set_parameter(s) fails.
+ */
+class magic_set_parameter_error final : public magic_exception {
 public:
-    magic_set_param_error(
-        const std::string& error,
+    /**
+     * @brief Construct magic_set_parameter_error with an error message,
+     *        the name of the parameter and its value.
+     *
+     * @param[in] error_message         The description of the error.
+     * @param[in] parameter_name        The names of the parameter.
+     * @param[in] value                 The value of the parameter.
+     */
+    magic_set_parameter_error(
+        const std::string& error_message,
         const std::string& parameter_name,
         std::size_t        value
     )
       : magic_exception{
-            std::format("magic_set_param({}, {})", parameter_name, value),
-            error
+            std::format("magic_set_parameter({}, {})", parameter_name, value),
+            error_message
         }
     { }
 };

--- a/sources/magic.cpp
+++ b/sources/magic.cpp
@@ -189,7 +189,7 @@ public:
             m_cookie.get(),
             path.string().c_str()
         );
-        throw_exception_on_failure<magic_file_error>(
+        throw_exception_on_failure<magic_identify_file_error>(
             type_cstr != nullptr,
             get_error_message(),
             path.string()
@@ -221,8 +221,8 @@ public:
         );
         if (!type_cstr) {
             return std::unexpected{
-                magic_file_error{get_error_message(), path.string()}
-                .what()
+                magic_identify_file_error{get_error_message(), path.string()}
+                    .what()
             };
         }
         return {type_cstr};

--- a/sources/magic.cpp
+++ b/sources/magic.cpp
@@ -400,7 +400,7 @@ public:
         const auto& libmagic_parameter{
             libmagic_parameters[std::to_underlying(parameter)]
         };
-        throw_exception_on_failure<magic_set_param_error>(
+        throw_exception_on_failure<magic_set_parameter_error>(
             detail::magic_setparam(
                 m_cookie.get(),
                 libmagic_pair_converter(libmagic_parameter),


### PR DESCRIPTION
## Description

Magicxx: API change - Rename magic_set_param_error and magic_file_error.

+ Rename magic_file_error to magic_identify_file_error for consistency and clarity in exception handling.

+ Rename magic_set_param_error to magic_set_parameter_error for consistency and clarity in exception handling.

Fixes issue #113.

...

## Checklist

+ [x] I have read the [CONTRIBUTING.md](https://github.com/oguztoraman/libmagicxx/blob/main/CONTRIBUTING.md).
+ [x] Changes follow the project's coding style.
+ [ ] Changes pass all new and existing unit tests.
+ [x] Changes are documented with Doxygen.
+ [x] Related documentation is updated.

### Title Format Guidelines

+ For bug fixes: `BUGFIX: Brief Description, Fixes issue #????.`
+ For documentation changes: `DOCUMENTATION: Brief Description, Fixes issue #????.`
+ For enhancements: `ENHANCEMENT: Brief Description, Fixes issue #????.`
+ For code quality improvements: `QUALITY: Brief Description, Fixes issue #????.`
