### PR TITLE
[ENHANCEMENT]; Magicxx: Add filesystem_error &  Throw filesystem_error from identify_files(directory) if the underlying std::filesystem OS API fail, Fixes issue #128.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Next Release
+
++ [**ENHANCEMENT**]**;** Magicxx: Throw filesystem_error from identify_files(directory) if the underlying std::filesystem OS API fails.
+
 + [**ENHANCEMENT**]**;** Magicxx: Add filesystem_error.
 
 + [**QUALITY**]**;** Magicxx: Refactor identify_file(s).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Next Release
++ [**ENHANCEMENT**]**;** Magicxx: Add filesystem_error.
 
 + [**QUALITY**]**;** Magicxx: Refactor identify_file(s).
 

--- a/include/magicxx/magic.hpp
+++ b/include/magicxx/magic.hpp
@@ -403,6 +403,7 @@ public:
      * @throws empty_path                   if the path of the directory is empty.
      * @throws path_does_not_exist          if the path of the directory does not exist.
      * @throws path_is_not_directory        if the path of the directory is not a directory.
+     * @throws filesystem_error             if the underlying std::filesystem OS API fails.
      * @throws magic_identify_file_error    if identifying the type of the file fails.
      */
     [[nodiscard]] types_of_files_t identify_files(

--- a/include/magicxx/magic_exception.hpp
+++ b/include/magicxx/magic_exception.hpp
@@ -109,6 +109,24 @@ public:
 };
 
 /**
+ * @class filesystem_error
+ *
+ * @brief Exception thrown when the underlying std::filesystem OS API fails.
+ */
+class filesystem_error final : public magic_exception {
+public:
+    /**
+     * @brief Construct filesystem_error with a path and an error message.
+     *
+     * @param[in] path                  The path related to the error.
+     * @param[in] error_message         The description of the error.
+     */
+    filesystem_error(const std::string& path, const std::string& error_message)
+      : magic_exception{std::format("'{}': {}.", path, error_message)}
+    { }
+};
+
+/**
  * @class magic_is_closed
  *
  * @brief Exception thrown when magic is closed.

--- a/sources/magic.cpp
+++ b/sources/magic.cpp
@@ -961,8 +961,18 @@ magic::types_of_files_t magic::identify_files(
         std::filesystem::is_directory(directory, error_code),
         directory.string()
     );
+    auto files = std::filesystem::recursive_directory_iterator{
+        directory,
+        option,
+        error_code
+    };
+    magic_private::throw_exception_on_failure<filesystem_error>(
+        !error_code,
+        directory.string(),
+        error_code.message()
+    );
     return m_impl->identify_files(
-        std::filesystem::recursive_directory_iterator{directory, option},
+        files,
         magic_private::identify_file_options::check_nothing
     );
 }


### PR DESCRIPTION
## Description

Magicxx: Add filesystem_error &  Throw filesystem_error from identify_files(directory) if the underlying std::filesystem OS API fails.

Fixes issue #128.

...

## Checklist

+ [x] I have read the [CONTRIBUTING.md](https://github.com/oguztoraman/libmagicxx/blob/main/CONTRIBUTING.md).
+ [x] Changes follow the project's coding style.
+ [ ] Changes pass all new and existing unit tests.
+ [x] Changes are documented with Doxygen.
+ [x] Related documentation is updated.

### Title Format Guidelines

+ For bug fixes: `[BUGFIX]; Brief Description, Fixes issue #????.`
+ For documentation changes: `[DOCUMENTATION]; Brief Description, Fixes issue #????.`
+ For enhancements: `[ENHANCEMENT]; Brief Description, Fixes issue #????.`
+ For code quality improvements: `[QUALITY]; Brief Description, Fixes issue #????.`
