### PR TITLE
[BUGFIX] CMake: Fix MAGICXX_FOUND logic and set export name for targets, Fixes issue #177.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ **[BUGFIX]** CMake: Fix MAGICXX_FOUND logic and set export name for targets.
+
 + **[ENHANCEMENT]** CMake: Add CMake style guide and apply consistent documentation, formatting, and modern target naming (Recognition::Magicxx) across all CMake files.
 
 + **[ENHANCEMENT]** Magic: Rename tracker variables to progress_tracker for improved clarity.

--- a/cmake/MagicxxConfig.cmake.in
+++ b/cmake/MagicxxConfig.cmake.in
@@ -55,9 +55,15 @@ if(TARGET Recognition::MagicxxStatic)
     )
 endif()
 
-set(MAGICXX_FOUND
-    TRUE
-)
+if(MAGICXX_SHARED_LIB_AVAILABLE OR MAGICXX_STATIC_LIB_AVAILABLE)
+    set(MAGICXX_FOUND
+        TRUE
+    )
+else()
+    set(MAGICXX_FOUND
+        FALSE
+    )
+endif()
 
 set(MAGICXX_VERSION
     @magicxx_VERSION@

--- a/cmake/targets.cmake
+++ b/cmake/targets.cmake
@@ -9,6 +9,10 @@ function(configure_magicxx_target target_name alias_name library_type)
 
     add_library(Recognition::${alias_name} ALIAS ${target_name})
 
+    set_target_properties(${target_name} PROPERTIES
+        EXPORT_NAME ${alias_name}
+    )
+
     add_dependencies(${target_name} configure_file)
 
     set_target_properties(${target_name} PROPERTIES


### PR DESCRIPTION
## Description

CMake: Fix MAGICXX_FOUND logic and set export name for targets.

Fixes issue #177.

...

## Checklist

+ [x] I have read the [CONTRIBUTING.md](https://github.com/oguztoraman/libmagicxx/blob/main/CONTRIBUTING.md).
+ [x] Changes follow the project's coding style.
+ [x] Changes pass all new and existing unit tests.
+ [x] Changes are documented with Doxygen.
+ [x] Related documentation is updated.

### Title Format Guidelines

+ For bug fixes: `[BUGFIX] Brief Description, Fixes issue #????.`
+ For documentation changes: `[DOCUMENTATION] Brief Description, Fixes issue #????.`
+ For enhancements: `[ENHANCEMENT] Brief Description, Fixes issue #????.`
+ For code quality improvements: `[QUALITY] Brief Description, Fixes issue #????.`
