### PR TITLE
[BUGFIX] CMake, Format: Include example and test files in format and lint targets, Fixes issue #203.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ **[BUGFIX]** CMake, Format: Include example and test files in format and lint targets.
+
 + **[ENHANCEMENT]** CMake, CI/CD, Format: Add clang-tidy checks with preset and CI workflow.
 
 + **[ENHANCEMENT]** Magic, Tests: API CHANGE - Convert Flags to scoped enum class with FlagsMask bridge.

--- a/cmake/directories.cmake
+++ b/cmake/directories.cmake
@@ -48,6 +48,10 @@ set(magicxx_EXAMPLES_DIR
     ${magicxx_SOURCE_DIR}/examples
 )
 
+set(magicxx_TESTS_DIR
+    ${magicxx_SOURCE_DIR}/tests
+)
+
 set(magicxx_DEFAULT_DATABASE_DIR
     ${magicxx_SOURCE_DIR}/databases
 )

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -67,3 +67,32 @@ set(magicxx_HEADER_FILES
 set(magicxx_SOURCE_FILES
     ${magicxx_SOURCES_DIR}/magic.cpp
 )
+
+# -----------------------------------------------------------------------------
+# Magicxx example source files
+# -----------------------------------------------------------------------------
+set(magicxx_examples_SOURCE_FILES
+    ${magicxx_EXAMPLES_DIR}/magic_examples.cpp
+)
+
+# -----------------------------------------------------------------------------
+# Magicxx test source files
+# -----------------------------------------------------------------------------
+set(magicxx_tests_SOURCE_FILES
+    ${magicxx_TESTS_DIR}/magic_check_test.cpp
+    ${magicxx_TESTS_DIR}/magic_compile_test.cpp
+    ${magicxx_TESTS_DIR}/magic_flags_mask_test.cpp
+    ${magicxx_TESTS_DIR}/magic_flags_test.cpp
+    ${magicxx_TESTS_DIR}/magic_identify_container_test.cpp
+    ${magicxx_TESTS_DIR}/magic_identify_directory_test.cpp
+    ${magicxx_TESTS_DIR}/magic_identify_file_test.cpp
+    ${magicxx_TESTS_DIR}/magic_load_database_file_test.cpp
+    ${magicxx_TESTS_DIR}/magic_open_close_test.cpp
+    ${magicxx_TESTS_DIR}/magic_parameters_test.cpp
+    ${magicxx_TESTS_DIR}/magic_percentage_test.cpp
+    ${magicxx_TESTS_DIR}/magic_progress_tracker_test.cpp
+    ${magicxx_TESTS_DIR}/magic_special_members_test.cpp
+    ${magicxx_TESTS_DIR}/magic_to_string_test.cpp
+    ${magicxx_TESTS_DIR}/magic_version_test.cpp
+    ${magicxx_TESTS_DIR}/main.cpp
+)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -37,12 +37,8 @@ message(STATUS "  Database dir:     ${MAGICXX_DEFAULT_DATABASE_DIR}")
 message(STATUS "")
 
 # -----------------------------------------------------------------------------
-# Source files
+# Source files (defined in cmake/sources.cmake)
 # -----------------------------------------------------------------------------
-
-set(magicxx_examples_SOURCE_FILES
-    magic_examples.cpp
-)
 
 # -----------------------------------------------------------------------------
 # Helper function to configure an example executable

--- a/examples/magic_examples.cpp
+++ b/examples/magic_examples.cpp
@@ -321,7 +321,8 @@ void ExampleLifecycleManagement()
     Magic example_magic;
     std::println(
         std::cout,
-        "After default construction: IsOpen={}, IsDatabaseLoaded={}, IsValid={}",
+        "After default construction: IsOpen={}, IsDatabaseLoaded={}, "
+        "IsValid={}",
         example_magic.IsOpen(),
         example_magic.IsDatabaseLoaded(),
         example_magic.IsValid()
@@ -380,8 +381,8 @@ void ExampleVersionAndAllParameters()
     std::println(std::cout, "All parameters: {}", ToString(all_params));
 
     example_magic.SetParameters({
-        {Magic::Parameters::BytesMax,  1'024'000},
-        {Magic::Parameters::RegexMax,  4'096    }
+        {Magic::Parameters::BytesMax, 1'024'000},
+        {Magic::Parameters::RegexMax, 4'096    }
     });
     auto updated_params = example_magic.GetParameters();
     std::println(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,27 +14,8 @@ project(magicxx_tests
 )
 
 # -----------------------------------------------------------------------------
-# Source files
+# Source files (defined in cmake/sources.cmake)
 # -----------------------------------------------------------------------------
-
-set(magicxx_tests_SOURCE_FILES
-    magic_check_test.cpp
-    magic_compile_test.cpp
-    magic_flags_mask_test.cpp
-    magic_flags_test.cpp
-    magic_identify_container_test.cpp
-    magic_identify_directory_test.cpp
-    magic_identify_file_test.cpp
-    magic_load_database_file_test.cpp
-    magic_open_close_test.cpp
-    magic_parameters_test.cpp
-    magic_percentage_test.cpp
-    magic_progress_tracker_test.cpp
-    magic_special_members_test.cpp
-    magic_to_string_test.cpp
-    magic_version_test.cpp
-    main.cpp
-)
 
 # -----------------------------------------------------------------------------
 # Dependencies

--- a/tests/magic_flags_mask_test.cpp
+++ b/tests/magic_flags_mask_test.cpp
@@ -78,7 +78,8 @@ TEST_F(MagicFlagsMaskTest, operator_subscript_symlink)
 
 TEST_F(MagicFlagsMaskTest, operator_or_two_flags)
 {
-    Magic::FlagsMaskT mask = Magic::Flags::MimeType | Magic::Flags::MimeEncoding;
+    Magic::FlagsMaskT mask = Magic::Flags::MimeType
+                           | Magic::Flags::MimeEncoding;
     EXPECT_TRUE(mask[4uz]);
     EXPECT_TRUE(mask[10uz]);
     EXPECT_FALSE(mask[0uz]);
@@ -86,8 +87,8 @@ TEST_F(MagicFlagsMaskTest, operator_or_two_flags)
 
 TEST_F(MagicFlagsMaskTest, operator_or_mask_with_mask)
 {
-    Magic::FlagsMaskT mask_a = Magic::Flags::Debug;
-    Magic::FlagsMaskT mask_b = Magic::Flags::Compress;
+    Magic::FlagsMaskT mask_a   = Magic::Flags::Debug;
+    Magic::FlagsMaskT mask_b   = Magic::Flags::Compress;
     Magic::FlagsMaskT combined = mask_a | mask_b;
     EXPECT_TRUE(combined[0uz]);
     EXPECT_TRUE(combined[2uz]);
@@ -96,7 +97,7 @@ TEST_F(MagicFlagsMaskTest, operator_or_mask_with_mask)
 
 TEST_F(MagicFlagsMaskTest, operator_or_mask_with_flag)
 {
-    Magic::FlagsMaskT mask = Magic::Flags::Debug;
+    Magic::FlagsMaskT mask     = Magic::Flags::Debug;
     Magic::FlagsMaskT combined = mask | Magic::Flags::Symlink;
     EXPECT_TRUE(combined[0uz]);
     EXPECT_TRUE(combined[1uz]);
@@ -104,7 +105,7 @@ TEST_F(MagicFlagsMaskTest, operator_or_mask_with_flag)
 
 TEST_F(MagicFlagsMaskTest, operator_or_flag_with_mask)
 {
-    Magic::FlagsMaskT mask = Magic::Flags::Debug | Magic::Flags::Symlink;
+    Magic::FlagsMaskT mask     = Magic::Flags::Debug | Magic::Flags::Symlink;
     Magic::FlagsMaskT combined = Magic::Flags::Compress | mask;
     EXPECT_TRUE(combined[0uz]);
     EXPECT_TRUE(combined[1uz]);
@@ -113,8 +114,8 @@ TEST_F(MagicFlagsMaskTest, operator_or_flag_with_mask)
 
 TEST_F(MagicFlagsMaskTest, parenthesized_right_group)
 {
-    Magic::FlagsMaskT mask =
-        Magic::Flags::Debug | (Magic::Flags::Symlink | Magic::Flags::Compress);
+    Magic::FlagsMaskT mask = Magic::Flags::Debug
+                           | (Magic::Flags::Symlink | Magic::Flags::Compress);
     EXPECT_TRUE(mask[0uz]);
     EXPECT_TRUE(mask[1uz]);
     EXPECT_TRUE(mask[2uz]);
@@ -122,8 +123,8 @@ TEST_F(MagicFlagsMaskTest, parenthesized_right_group)
 
 TEST_F(MagicFlagsMaskTest, parenthesized_left_group)
 {
-    Magic::FlagsMaskT mask =
-        (Magic::Flags::Debug | Magic::Flags::Symlink) | Magic::Flags::Compress;
+    Magic::FlagsMaskT mask = (Magic::Flags::Debug | Magic::Flags::Symlink)
+                           | Magic::Flags::Compress;
     EXPECT_TRUE(mask[0uz]);
     EXPECT_TRUE(mask[1uz]);
     EXPECT_TRUE(mask[2uz]);
@@ -132,7 +133,7 @@ TEST_F(MagicFlagsMaskTest, parenthesized_left_group)
 TEST_F(MagicFlagsMaskTest, parenthesized_both_groups)
 {
     Magic::FlagsMaskT mask = (Magic::Flags::Debug | Magic::Flags::Symlink)
-                          | (Magic::Flags::Compress | Magic::Flags::Devices);
+                           | (Magic::Flags::Compress | Magic::Flags::Devices);
     EXPECT_TRUE(mask[0uz]);
     EXPECT_TRUE(mask[1uz]);
     EXPECT_TRUE(mask[2uz]);
@@ -142,9 +143,11 @@ TEST_F(MagicFlagsMaskTest, parenthesized_both_groups)
 
 TEST_F(MagicFlagsMaskTest, chained_or_multiple_flags)
 {
-    Magic::FlagsMaskT mask = Magic::Flags::Debug | Magic::Flags::Symlink
-                          | Magic::Flags::Compress | Magic::Flags::Devices
-                          | Magic::Flags::MimeType;
+    Magic::FlagsMaskT mask = Magic::Flags::Debug
+                           | Magic::Flags::Symlink
+                           | Magic::Flags::Compress
+                           | Magic::Flags::Devices
+                           | Magic::Flags::MimeType;
     EXPECT_TRUE(mask[0uz]);
     EXPECT_TRUE(mask[1uz]);
     EXPECT_TRUE(mask[2uz]);
@@ -154,8 +157,9 @@ TEST_F(MagicFlagsMaskTest, chained_or_multiple_flags)
 
 TEST_F(MagicFlagsMaskTest, or_with_same_flag_is_idempotent)
 {
-    Magic::FlagsMaskT mask =
-        Magic::Flags::Mime | Magic::Flags::Mime | Magic::Flags::Mime;
+    Magic::FlagsMaskT mask = Magic::Flags::Mime
+                           | Magic::Flags::Mime
+                           | Magic::Flags::Mime;
     EXPECT_TRUE(mask[11uz]);
     std::size_t set_count{};
     for (std::size_t i{}; i < mask.size(); ++i) {
@@ -181,7 +185,7 @@ TEST_F(MagicFlagsMaskTest, none_returns_false_for_set_flag)
 TEST_F(MagicFlagsMaskTest, size_is_always_thirty)
 {
     Magic::FlagsMaskT empty{};
-    Magic::FlagsMaskT single = Magic::Flags::Debug;
+    Magic::FlagsMaskT single   = Magic::Flags::Debug;
     Magic::FlagsMaskT combined = Magic::Flags::Debug | Magic::Flags::Symlink;
     EXPECT_EQ(30uz, empty.size());
     EXPECT_EQ(30uz, single.size());
@@ -199,7 +203,8 @@ TEST_F(MagicFlagsMaskTest, combined_flags_in_open_call)
 {
     Magic magic{};
     EXPECT_TRUE(magic.Open(
-        Magic::Flags::MimeType | Magic::Flags::MimeEncoding, std::nothrow
+        Magic::Flags::MimeType | Magic::Flags::MimeEncoding,
+        std::nothrow
     ));
     EXPECT_TRUE(magic.IsOpen());
 }
@@ -218,13 +223,16 @@ TEST_F(MagicFlagsMaskTest, all_individual_flags_set_correct_bit)
 {
     static constexpr std::size_t FLAG_COUNT{30uz};
     for (std::size_t bit{}; bit < FLAG_COUNT; ++bit) {
-        auto flag = static_cast<Magic::Flags>(1ULL << bit);
+        auto              flag = static_cast<Magic::Flags>(1ULL << bit);
         Magic::FlagsMaskT mask = flag;
         EXPECT_TRUE(mask[bit]) << "bit " << bit << " should be set";
         for (std::size_t other{}; other < FLAG_COUNT; ++other) {
             if (other != bit) {
                 EXPECT_FALSE(mask[other])
-                    << "bit " << other << " should not be set when bit " << bit
+                    << "bit "
+                    << other
+                    << " should not be set when bit "
+                    << bit
                     << " is the only flag";
             }
         }

--- a/tests/magic_flags_test.cpp
+++ b/tests/magic_flags_test.cpp
@@ -39,8 +39,10 @@ struct MagicFlagsTest : testing::Test {
 protected:
     MagicFlagsTest()
     {
-        EXPECT_TRUE(m_opened_magic_without_database
-                        .Open(Magic::Flags::Mime, std::nothrow));
+        EXPECT_TRUE(m_opened_magic_without_database.Open(
+            Magic::Flags::Mime,
+            std::nothrow
+        ));
         EXPECT_TRUE(m_valid_magic.IsValid());
         std::error_code error_code;
         EXPECT_TRUE(std::filesystem::exists(m_valid_database, error_code));
@@ -57,12 +59,9 @@ protected:
             static_cast<Magic::Flags>(1ULL << m_dist(m_eng)),
             static_cast<Magic::Flags>(1ULL << m_dist(m_eng))
         };
-        std::ranges::sort(
-            test_flags,
-            [](Magic::Flags a, Magic::Flags b) {
-                return std::to_underlying(a) < std::to_underlying(b);
-            }
-        );
+        std::ranges::sort(test_flags, [](Magic::Flags a, Magic::Flags b) {
+            return std::to_underlying(a) < std::to_underlying(b);
+        });
         m_test_flags_container.clear();
         m_test_flags_container.assign(test_flags.begin(), test_flags.end());
         m_test_flags_container.erase(
@@ -75,7 +74,9 @@ protected:
         m_test_flags_mask = std::ranges::fold_left(
             m_test_flags_container,
             Magic::FlagsMaskT{},
-            [](Magic::FlagsMaskT acc, Magic::Flags f) { return acc | f; }
+            [](Magic::FlagsMaskT acc, Magic::Flags f) {
+                return acc | f;
+            }
         );
     }
 
@@ -83,8 +84,8 @@ protected:
     Magic                 m_closed_magic{};
     Magic                 m_opened_magic_without_database;
     Magic m_valid_magic{Magic::Flags::Mime, std::nothrow, m_valid_database};
-    Magic::FlagsContainerT                   m_test_flags_container{};
-    Magic::FlagsMaskT                        m_test_flags_mask{};
+    Magic::FlagsContainerT                     m_test_flags_container{};
+    Magic::FlagsMaskT                          m_test_flags_mask{};
     std::mt19937                               m_eng{std::random_device{}()};
     std::uniform_int_distribution<std::size_t> m_dist{
         0,
@@ -112,16 +113,12 @@ TEST_F(MagicFlagsTest, closed_magic_set_flags_container)
 
 TEST_F(MagicFlagsTest, closed_magic_set_flags_container_noexcept)
 {
-    EXPECT_FALSE(m_closed_magic.SetFlags(m_test_flags_container, std::nothrow)
-    );
+    EXPECT_FALSE(m_closed_magic.SetFlags(m_test_flags_container, std::nothrow));
 }
 
 TEST_F(MagicFlagsTest, closed_magic_get_flags)
 {
-    EXPECT_THROW(
-        static_cast<void>(m_closed_magic.GetFlags()),
-        MagicIsClosed
-    );
+    EXPECT_THROW(static_cast<void>(m_closed_magic.GetFlags()), MagicIsClosed);
 }
 
 TEST_F(MagicFlagsTest, closed_magic_get_flags_noexcept)
@@ -131,7 +128,8 @@ TEST_F(MagicFlagsTest, closed_magic_get_flags_noexcept)
 
 TEST_F(MagicFlagsTest, opened_magic_without_database_flags_mask)
 {
-    EXPECT_NO_THROW(m_opened_magic_without_database.SetFlags(m_test_flags_mask)
+    EXPECT_NO_THROW(
+        m_opened_magic_without_database.SetFlags(m_test_flags_mask)
     );
     EXPECT_EQ(
         m_test_flags_container,
@@ -141,8 +139,10 @@ TEST_F(MagicFlagsTest, opened_magic_without_database_flags_mask)
 
 TEST_F(MagicFlagsTest, opened_magic_without_database_flags_mask_noexcept)
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .SetFlags(m_test_flags_mask, std::nothrow));
+    EXPECT_TRUE(m_opened_magic_without_database.SetFlags(
+        m_test_flags_mask,
+        std::nothrow
+    ));
     EXPECT_EQ(
         m_test_flags_container,
         m_opened_magic_without_database.GetFlags(std::nothrow).value()
@@ -162,8 +162,10 @@ TEST_F(MagicFlagsTest, opened_magic_without_database_flags_container)
 
 TEST_F(MagicFlagsTest, opened_magic_without_database_flags_container_noexcept)
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .SetFlags(m_test_flags_container, std::nothrow));
+    EXPECT_TRUE(m_opened_magic_without_database.SetFlags(
+        m_test_flags_container,
+        std::nothrow
+    ));
     EXPECT_EQ(
         m_test_flags_container,
         m_opened_magic_without_database.GetFlags(std::nothrow).value()

--- a/tests/magic_identify_container_test.cpp
+++ b/tests/magic_identify_container_test.cpp
@@ -42,8 +42,10 @@ struct MagicIdentifyContainerTest : testing::Test {
 protected:
     MagicIdentifyContainerTest()
     {
-        EXPECT_TRUE(m_opened_magic_without_database
-                        .Open(Magic::Flags::Mime, std::nothrow));
+        EXPECT_TRUE(m_opened_magic_without_database.Open(
+            Magic::Flags::Mime,
+            std::nothrow
+        ));
         EXPECT_FALSE(m_opened_magic_without_database.IsDatabaseLoaded());
         EXPECT_TRUE(m_valid_magic.IsValid());
         std::filesystem::create_directory(m_test_dir, m_error_code);
@@ -77,12 +79,12 @@ protected:
     std::filesystem::path m_test_dir{
         std::filesystem::temp_directory_path() / "magic_identify_container_test"
     };
-    std::filesystem::path   m_nonexistent_path{m_test_dir / "nonexistent_path"};
-    std::filesystem::path   m_text_file   = m_test_dir / "text.txt";
-    std::filesystem::path   m_binary_file = m_test_dir / "binary.txt";
-    Magic::FileTypeMapT m_types_of_valid_files{
-        {m_text_file,   "text/plain; charset=us-ascii"            },
-        {m_binary_file, "application/octet-stream; charset=binary"}
+    std::filesystem::path m_nonexistent_path{m_test_dir / "nonexistent_path"};
+    std::filesystem::path m_text_file   = m_test_dir / "text.txt";
+    std::filesystem::path m_binary_file = m_test_dir / "binary.txt";
+    Magic::FileTypeMapT   m_types_of_valid_files{
+          {m_text_file,   "text/plain; charset=us-ascii"            },
+          {m_binary_file, "application/octet-stream; charset=binary"}
     };
     Magic::ExpectedFileTypeMapT m_expected_types_of_valid_files{
         {m_text_file,   "text/plain; charset=us-ascii"            },
@@ -94,10 +96,9 @@ protected:
         m_nonexistent_path,
         m_nonexistent_path
     };
-    Magic::ExpectedFileTypeMapT
-        m_expected_types_of_nonexistent_path_container{
-            {m_nonexistent_path,
-             std::unexpected{PathDoesNotExist{m_nonexistent_path}.what()}}
+    Magic::ExpectedFileTypeMapT m_expected_types_of_nonexistent_path_container{
+        {m_nonexistent_path,
+         std::unexpected{PathDoesNotExist{m_nonexistent_path}.what()}}
     };
     std::vector<std::filesystem::path> m_valid_container{
         m_text_file,
@@ -124,9 +125,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_closed_magic.IdentifyFiles(m_empty_container, m_null_progress_tracker)
-        ),
+        static_cast<void>(m_closed_magic.IdentifyFiles(
+            m_empty_container,
+            m_null_progress_tracker
+        )),
         MagicIsClosed
     );
 }
@@ -154,11 +156,13 @@ TEST_F(
     closed_magic_empty_container_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(
-        m_closed_magic
-            .IdentifyFiles(m_empty_container, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_closed_magic
+                    .IdentifyFiles(
+                        m_empty_container,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(
@@ -166,17 +170,18 @@ TEST_F(
     closed_magic_empty_container_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_closed_magic
-                    .IdentifyFiles(m_empty_container, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_closed_magic
+            .IdentifyFiles(m_empty_container, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
 TEST_F(MagicIdentifyContainerTest, closed_magic_empty_path_container)
 {
     EXPECT_THROW(
-        static_cast<void>(m_closed_magic.IdentifyFiles(m_empty_path_container)
-        ),
+        static_cast<void>(m_closed_magic.IdentifyFiles(m_empty_path_container)),
         MagicIsClosed
     );
 }
@@ -201,18 +206,16 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_closed_magic.IdentifyFiles(m_empty_path_container, m_progress_tracker)
-        ),
+        static_cast<void>(m_closed_magic.IdentifyFiles(
+            m_empty_path_container,
+            m_progress_tracker
+        )),
         MagicIsClosed
     );
     EXPECT_FALSE(m_progress_tracker->IsCompleted());
 }
 
-TEST_F(
-    MagicIdentifyContainerTest,
-    closed_magic_empty_path_container_noexcept
-)
+TEST_F(MagicIdentifyContainerTest, closed_magic_empty_path_container_noexcept)
 {
     EXPECT_TRUE(m_closed_magic
                     .IdentifyFiles(m_empty_path_container, std::nothrow)
@@ -238,11 +241,13 @@ TEST_F(
     closed_magic_empty_path_container_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(
-        m_closed_magic
-            .IdentifyFiles(m_empty_path_container, std::nothrow, m_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_closed_magic
+                    .IdentifyFiles(
+                        m_empty_path_container,
+                        std::nothrow,
+                        m_progress_tracker
+                    )
+                    .empty());
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -338,17 +343,15 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_closed_magic.IdentifyFiles(m_valid_container, m_null_progress_tracker)
-        ),
+        static_cast<void>(m_closed_magic.IdentifyFiles(
+            m_valid_container,
+            m_null_progress_tracker
+        )),
         MagicIsClosed
     );
 }
 
-TEST_F(
-    MagicIdentifyContainerTest,
-    closed_magic_valid_contaniner_with_tracker
-)
+TEST_F(MagicIdentifyContainerTest, closed_magic_valid_contaniner_with_tracker)
 {
     EXPECT_THROW(
         static_cast<void>(
@@ -371,11 +374,13 @@ TEST_F(
     closed_magic_valid_contaniner_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(
-        m_closed_magic
-            .IdentifyFiles(m_valid_container, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_closed_magic
+                    .IdentifyFiles(
+                        m_valid_container,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(
@@ -383,9 +388,11 @@ TEST_F(
     closed_magic_valid_contaniner_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_closed_magic
-                    .IdentifyFiles(m_valid_container, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_closed_magic
+            .IdentifyFiles(m_valid_container, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -422,8 +429,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(m_opened_magic_without_database
-                              .IdentifyFiles(m_empty_container, m_progress_tracker)),
+        static_cast<void>(m_opened_magic_without_database.IdentifyFiles(
+            m_empty_container,
+            m_progress_tracker
+        )),
         MagicDatabaseNotLoaded
     );
     EXPECT_FALSE(m_progress_tracker->IsCompleted());
@@ -444,11 +453,13 @@ TEST_F(
     opened_magic_without_database_empty_container_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(
-        m_opened_magic_without_database
-            .IdentifyFiles(m_empty_container, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_opened_magic_without_database
+                    .IdentifyFiles(
+                        m_empty_container,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(
@@ -456,9 +467,11 @@ TEST_F(
     opened_magic_without_database_empty_container_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .IdentifyFiles(m_empty_container, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_opened_magic_without_database
+            .IdentifyFiles(m_empty_container, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -533,11 +546,13 @@ TEST_F(
     opened_magic_without_database_empty_path_container_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(
-        m_opened_magic_without_database
-            .IdentifyFiles(m_empty_path_container, std::nothrow, m_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_opened_magic_without_database
+                    .IdentifyFiles(
+                        m_empty_path_container,
+                        std::nothrow,
+                        m_progress_tracker
+                    )
+                    .empty());
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -655,8 +670,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(m_opened_magic_without_database
-                              .IdentifyFiles(m_valid_container, m_progress_tracker)),
+        static_cast<void>(m_opened_magic_without_database.IdentifyFiles(
+            m_valid_container,
+            m_progress_tracker
+        )),
         MagicDatabaseNotLoaded
     );
     EXPECT_FALSE(m_progress_tracker->IsCompleted());
@@ -677,11 +694,13 @@ TEST_F(
     opened_magic_without_database_valid_contaniner_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(
-        m_opened_magic_without_database
-            .IdentifyFiles(m_valid_container, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_opened_magic_without_database
+                    .IdentifyFiles(
+                        m_valid_container,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(
@@ -689,9 +708,11 @@ TEST_F(
     opened_magic_without_database_valid_contaniner_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .IdentifyFiles(m_valid_container, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_opened_magic_without_database
+            .IdentifyFiles(m_valid_container, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -706,18 +727,19 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_valid_magic.IdentifyFiles(m_empty_container, m_null_progress_tracker)
-        ),
+        static_cast<void>(m_valid_magic.IdentifyFiles(
+            m_empty_container,
+            m_null_progress_tracker
+        )),
         NullTracker
     );
 }
 
 TEST_F(MagicIdentifyContainerTest, valid_magic_empty_container_with_tracker)
 {
-    EXPECT_TRUE(
-        m_valid_magic.IdentifyFiles(m_empty_container, m_progress_tracker).empty()
-    );
+    EXPECT_TRUE(m_valid_magic
+                    .IdentifyFiles(m_empty_container, m_progress_tracker)
+                    .empty());
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -733,11 +755,13 @@ TEST_F(
     valid_magic_empty_container_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(
-        m_valid_magic
-            .IdentifyFiles(m_empty_container, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_valid_magic
+                    .IdentifyFiles(
+                        m_empty_container,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(
@@ -745,9 +769,11 @@ TEST_F(
     valid_magic_empty_container_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_valid_magic
-                    .IdentifyFiles(m_empty_container, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_valid_magic
+            .IdentifyFiles(m_empty_container, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -765,9 +791,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_valid_magic.IdentifyFiles(m_empty_path_container, m_null_progress_tracker)
-        ),
+        static_cast<void>(m_valid_magic.IdentifyFiles(
+            m_empty_path_container,
+            m_null_progress_tracker
+        )),
         NullTracker
     );
 }
@@ -778,9 +805,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_valid_magic.IdentifyFiles(m_empty_path_container, m_progress_tracker)
-        ),
+        static_cast<void>(m_valid_magic.IdentifyFiles(
+            m_empty_path_container,
+            m_progress_tracker
+        )),
         EmptyPath
     );
     EXPECT_FALSE(m_progress_tracker->IsCompleted());
@@ -812,11 +840,13 @@ TEST_F(
     valid_magic_empty_path_container_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(
-        m_valid_magic
-            .IdentifyFiles(m_empty_path_container, std::nothrow, m_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_valid_magic
+                    .IdentifyFiles(
+                        m_empty_path_container,
+                        std::nothrow,
+                        m_progress_tracker
+                    )
+                    .empty());
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -865,8 +895,7 @@ TEST_F(
 )
 {
     EXPECT_EQ(
-        m_valid_magic
-            .IdentifyFiles(m_nonexistent_path_container, std::nothrow),
+        m_valid_magic.IdentifyFiles(m_nonexistent_path_container, std::nothrow),
         m_expected_types_of_nonexistent_path_container
     );
 }
@@ -915,9 +944,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_valid_magic.IdentifyFiles(m_valid_container, m_null_progress_tracker)
-        ),
+        static_cast<void>(m_valid_magic.IdentifyFiles(
+            m_valid_container,
+            m_null_progress_tracker
+        )),
         NullTracker
     );
 }
@@ -944,11 +974,13 @@ TEST_F(
     valid_magic_valid_container_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(
-        m_valid_magic
-            .IdentifyFiles(m_valid_container, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_valid_magic
+                    .IdentifyFiles(
+                        m_valid_container,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(
@@ -957,8 +989,11 @@ TEST_F(
 )
 {
     EXPECT_EQ(
-        m_valid_magic
-            .IdentifyFiles(m_valid_container, std::nothrow, m_progress_tracker),
+        m_valid_magic.IdentifyFiles(
+            m_valid_container,
+            std::nothrow,
+            m_progress_tracker
+        ),
         m_expected_types_of_valid_files
     );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());

--- a/tests/magic_identify_directory_test.cpp
+++ b/tests/magic_identify_directory_test.cpp
@@ -45,8 +45,10 @@ struct MagicIdentifyDirectoryTest : testing::Test {
 protected:
     MagicIdentifyDirectoryTest()
     {
-        EXPECT_TRUE(m_opened_magic_without_database
-                        .Open(Magic::Flags::Mime, std::nothrow));
+        EXPECT_TRUE(m_opened_magic_without_database.Open(
+            Magic::Flags::Mime,
+            std::nothrow
+        ));
         EXPECT_FALSE(m_opened_magic_without_database.IsDatabaseLoaded());
         EXPECT_TRUE(m_valid_magic.IsValid());
         std::filesystem::create_directory(m_test_dir, m_error_code);
@@ -83,14 +85,14 @@ protected:
     std::filesystem::path m_test_dir{
         std::filesystem::temp_directory_path() / "magic_identify_directory_test"
     };
-    std::filesystem::path   m_empty_dir{m_test_dir / "empty_directory"};
-    std::filesystem::path   m_nonexistent_path{m_test_dir / "nonexistent_path"};
-    std::filesystem::path   m_text_file   = m_test_dir / "text.txt";
-    std::filesystem::path   m_binary_file = m_test_dir / "binary.txt";
-    Magic::FileTypeMapT m_types_of_valid_files{
-        {m_text_file,   "text/plain; charset=us-ascii"            },
-        {m_empty_dir,   "inode/directory; charset=binary"         },
-        {m_binary_file, "application/octet-stream; charset=binary"}
+    std::filesystem::path m_empty_dir{m_test_dir / "empty_directory"};
+    std::filesystem::path m_nonexistent_path{m_test_dir / "nonexistent_path"};
+    std::filesystem::path m_text_file   = m_test_dir / "text.txt";
+    std::filesystem::path m_binary_file = m_test_dir / "binary.txt";
+    Magic::FileTypeMapT   m_types_of_valid_files{
+          {m_text_file,   "text/plain; charset=us-ascii"            },
+          {m_empty_dir,   "inode/directory; charset=binary"         },
+          {m_binary_file, "application/octet-stream; charset=binary"}
     };
     Magic::ExpectedFileTypeMapT m_expected_types_of_valid_files{
         {m_text_file,   "text/plain; charset=us-ascii"            },
@@ -125,7 +127,8 @@ TEST_F(MagicIdentifyDirectoryTest, closed_magic_empty_path_with_null_tracker)
 TEST_F(MagicIdentifyDirectoryTest, closed_magic_empty_path_with_tracker)
 {
     EXPECT_THROW(
-        static_cast<void>(m_closed_magic.IdentifyFiles(m_empty_path, m_progress_tracker)
+        static_cast<void>(
+            m_closed_magic.IdentifyFiles(m_empty_path, m_progress_tracker)
         ),
         MagicIsClosed
     );
@@ -144,9 +147,11 @@ TEST_F(
     closed_magic_empty_path_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(m_closed_magic
-                    .IdentifyFiles(m_empty_path, std::nothrow, m_null_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_closed_magic
+            .IdentifyFiles(m_empty_path, std::nothrow, m_null_progress_tracker)
+            .empty()
+    );
 }
 
 TEST_F(
@@ -154,9 +159,11 @@ TEST_F(
     closed_magic_empty_path_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_closed_magic
-                    .IdentifyFiles(m_empty_path, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_closed_magic
+            .IdentifyFiles(m_empty_path, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -174,17 +181,15 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_closed_magic.IdentifyFiles(m_nonexistent_path, m_null_progress_tracker)
-        ),
+        static_cast<void>(m_closed_magic.IdentifyFiles(
+            m_nonexistent_path,
+            m_null_progress_tracker
+        )),
         MagicIsClosed
     );
 }
 
-TEST_F(
-    MagicIdentifyDirectoryTest,
-    closed_magic_nonexistent_path_with_tracker
-)
+TEST_F(MagicIdentifyDirectoryTest, closed_magic_nonexistent_path_with_tracker)
 {
     EXPECT_THROW(
         static_cast<void>(
@@ -207,11 +212,13 @@ TEST_F(
     closed_magic_nonexistent_path_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(
-        m_closed_magic
-            .IdentifyFiles(m_nonexistent_path, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_closed_magic
+                    .IdentifyFiles(
+                        m_nonexistent_path,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(
@@ -219,9 +226,11 @@ TEST_F(
     closed_magic_nonexistent_path_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_closed_magic
-                    .IdentifyFiles(m_nonexistent_path, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_closed_magic
+            .IdentifyFiles(m_nonexistent_path, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -236,9 +245,10 @@ TEST_F(MagicIdentifyDirectoryTest, closed_magic_file)
 TEST_F(MagicIdentifyDirectoryTest, closed_magic_file_with_null_tracker)
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_closed_magic.IdentifyFiles(m_valid_database, m_null_progress_tracker)
-        ),
+        static_cast<void>(m_closed_magic.IdentifyFiles(
+            m_valid_database,
+            m_null_progress_tracker
+        )),
         MagicIsClosed
     );
 }
@@ -261,23 +271,24 @@ TEST_F(MagicIdentifyDirectoryTest, closed_magic_file_noexcept)
     );
 }
 
-TEST_F(
-    MagicIdentifyDirectoryTest,
-    closed_magic_file_noexcept_with_null_tracker
-)
+TEST_F(MagicIdentifyDirectoryTest, closed_magic_file_noexcept_with_null_tracker)
 {
-    EXPECT_TRUE(
-        m_closed_magic
-            .IdentifyFiles(m_valid_database, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_closed_magic
+                    .IdentifyFiles(
+                        m_valid_database,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(MagicIdentifyDirectoryTest, closed_magic_file_noexcept_with_tracker)
 {
-    EXPECT_TRUE(m_closed_magic
-                    .IdentifyFiles(m_valid_database, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_closed_magic
+            .IdentifyFiles(m_valid_database, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -305,7 +316,8 @@ TEST_F(
 TEST_F(MagicIdentifyDirectoryTest, closed_magic_empty_directory_with_tracker)
 {
     EXPECT_THROW(
-        static_cast<void>(m_closed_magic.IdentifyFiles(m_empty_dir, m_progress_tracker)
+        static_cast<void>(
+            m_closed_magic.IdentifyFiles(m_empty_dir, m_progress_tracker)
         ),
         MagicIsClosed
     );
@@ -314,7 +326,8 @@ TEST_F(MagicIdentifyDirectoryTest, closed_magic_empty_directory_with_tracker)
 
 TEST_F(MagicIdentifyDirectoryTest, closed_magic_empty_directory_noexcept)
 {
-    EXPECT_TRUE(m_closed_magic.IdentifyFiles(m_empty_dir, std::nothrow).empty()
+    EXPECT_TRUE(
+        m_closed_magic.IdentifyFiles(m_empty_dir, std::nothrow).empty()
     );
 }
 
@@ -323,9 +336,11 @@ TEST_F(
     closed_magic_empty_directory_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(m_closed_magic
-                    .IdentifyFiles(m_empty_dir, std::nothrow, m_null_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_closed_magic
+            .IdentifyFiles(m_empty_dir, std::nothrow, m_null_progress_tracker)
+            .empty()
+    );
 }
 
 TEST_F(
@@ -333,9 +348,11 @@ TEST_F(
     closed_magic_empty_directory_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_closed_magic
-                    .IdentifyFiles(m_empty_dir, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_closed_magic
+            .IdentifyFiles(m_empty_dir, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -363,7 +380,9 @@ TEST_F(
 TEST_F(MagicIdentifyDirectoryTest, closed_magic_valid_directory_with_tracker)
 {
     EXPECT_THROW(
-        static_cast<void>(m_closed_magic.IdentifyFiles(m_test_dir, m_progress_tracker)),
+        static_cast<void>(
+            m_closed_magic.IdentifyFiles(m_test_dir, m_progress_tracker)
+        ),
         MagicIsClosed
     );
     EXPECT_FALSE(m_progress_tracker->IsCompleted());
@@ -371,8 +390,7 @@ TEST_F(MagicIdentifyDirectoryTest, closed_magic_valid_directory_with_tracker)
 
 TEST_F(MagicIdentifyDirectoryTest, closed_magic_valid_directory_noexcept)
 {
-    EXPECT_TRUE(m_closed_magic.IdentifyFiles(m_test_dir, std::nothrow).empty()
-    );
+    EXPECT_TRUE(m_closed_magic.IdentifyFiles(m_test_dir, std::nothrow).empty());
 }
 
 TEST_F(
@@ -380,9 +398,11 @@ TEST_F(
     closed_magic_valid_directory_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(m_closed_magic
-                    .IdentifyFiles(m_test_dir, std::nothrow, m_null_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_closed_magic
+            .IdentifyFiles(m_test_dir, std::nothrow, m_null_progress_tracker)
+            .empty()
+    );
 }
 
 TEST_F(
@@ -412,8 +432,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(m_opened_magic_without_database
-                              .IdentifyFiles(m_empty_path, m_null_progress_tracker)),
+        static_cast<void>(m_opened_magic_without_database.IdentifyFiles(
+            m_empty_path,
+            m_null_progress_tracker
+        )),
         MagicDatabaseNotLoaded
     );
 }
@@ -424,8 +446,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(m_opened_magic_without_database
-                              .IdentifyFiles(m_empty_path, m_progress_tracker)),
+        static_cast<void>(m_opened_magic_without_database.IdentifyFiles(
+            m_empty_path,
+            m_progress_tracker
+        )),
         MagicDatabaseNotLoaded
     );
     EXPECT_FALSE(m_progress_tracker->IsCompleted());
@@ -446,9 +470,11 @@ TEST_F(
     opened_magic_without_database_empty_path_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .IdentifyFiles(m_empty_path, std::nothrow, m_null_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_opened_magic_without_database
+            .IdentifyFiles(m_empty_path, std::nothrow, m_null_progress_tracker)
+            .empty()
+    );
 }
 
 TEST_F(
@@ -456,9 +482,11 @@ TEST_F(
     opened_magic_without_database_empty_path_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .IdentifyFiles(m_empty_path, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_opened_magic_without_database
+            .IdentifyFiles(m_empty_path, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -495,8 +523,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(m_opened_magic_without_database
-                              .IdentifyFiles(m_nonexistent_path, m_progress_tracker)),
+        static_cast<void>(m_opened_magic_without_database.IdentifyFiles(
+            m_nonexistent_path,
+            m_progress_tracker
+        )),
         MagicDatabaseNotLoaded
     );
     EXPECT_FALSE(m_progress_tracker->IsCompleted());
@@ -517,11 +547,13 @@ TEST_F(
     opened_magic_without_database_nonexistent_path_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(
-        m_opened_magic_without_database
-            .IdentifyFiles(m_nonexistent_path, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_opened_magic_without_database
+                    .IdentifyFiles(
+                        m_nonexistent_path,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(
@@ -529,9 +561,11 @@ TEST_F(
     opened_magic_without_database_nonexistent_path_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .IdentifyFiles(m_nonexistent_path, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_opened_magic_without_database
+            .IdentifyFiles(m_nonexistent_path, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -565,17 +599,16 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(m_opened_magic_without_database
-                              .IdentifyFiles(m_valid_database, m_progress_tracker)),
+        static_cast<void>(m_opened_magic_without_database.IdentifyFiles(
+            m_valid_database,
+            m_progress_tracker
+        )),
         MagicDatabaseNotLoaded
     );
     EXPECT_FALSE(m_progress_tracker->IsCompleted());
 }
 
-TEST_F(
-    MagicIdentifyDirectoryTest,
-    opened_magic_without_database_file_noexcept
-)
+TEST_F(MagicIdentifyDirectoryTest, opened_magic_without_database_file_noexcept)
 {
     EXPECT_TRUE(m_opened_magic_without_database
                     .IdentifyFiles(m_valid_database, std::nothrow)
@@ -587,11 +620,13 @@ TEST_F(
     opened_magic_without_database_file_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(
-        m_opened_magic_without_database
-            .IdentifyFiles(m_valid_database, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_opened_magic_without_database
+                    .IdentifyFiles(
+                        m_valid_database,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(
@@ -599,9 +634,11 @@ TEST_F(
     opened_magic_without_database_file_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .IdentifyFiles(m_valid_database, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_opened_magic_without_database
+            .IdentifyFiles(m_valid_database, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -624,8 +661,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(m_opened_magic_without_database
-                              .IdentifyFiles(m_empty_dir, m_null_progress_tracker)),
+        static_cast<void>(m_opened_magic_without_database.IdentifyFiles(
+            m_empty_dir,
+            m_null_progress_tracker
+        )),
         MagicDatabaseNotLoaded
     );
 }
@@ -636,8 +675,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(m_opened_magic_without_database
-                              .IdentifyFiles(m_empty_dir, m_progress_tracker)),
+        static_cast<void>(m_opened_magic_without_database.IdentifyFiles(
+            m_empty_dir,
+            m_progress_tracker
+        )),
         MagicDatabaseNotLoaded
     );
     EXPECT_FALSE(m_progress_tracker->IsCompleted());
@@ -658,9 +699,11 @@ TEST_F(
     opened_magic_without_database_empty_directory_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .IdentifyFiles(m_empty_dir, std::nothrow, m_null_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_opened_magic_without_database
+            .IdentifyFiles(m_empty_dir, std::nothrow, m_null_progress_tracker)
+            .empty()
+    );
 }
 
 TEST_F(
@@ -668,9 +711,11 @@ TEST_F(
     opened_magic_without_database_empty_directory_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .IdentifyFiles(m_empty_dir, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_opened_magic_without_database
+            .IdentifyFiles(m_empty_dir, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -693,8 +738,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(m_opened_magic_without_database
-                              .IdentifyFiles(m_test_dir, m_null_progress_tracker)),
+        static_cast<void>(m_opened_magic_without_database.IdentifyFiles(
+            m_test_dir,
+            m_null_progress_tracker
+        )),
         MagicDatabaseNotLoaded
     );
 }
@@ -705,8 +752,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(m_opened_magic_without_database
-                              .IdentifyFiles(m_test_dir, m_progress_tracker)),
+        static_cast<void>(m_opened_magic_without_database.IdentifyFiles(
+            m_test_dir,
+            m_progress_tracker
+        )),
         MagicDatabaseNotLoaded
     );
     EXPECT_FALSE(m_progress_tracker->IsCompleted());
@@ -727,9 +776,11 @@ TEST_F(
     opened_magic_without_database_valid_directory_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .IdentifyFiles(m_test_dir, std::nothrow, m_null_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_opened_magic_without_database
+            .IdentifyFiles(m_test_dir, std::nothrow, m_null_progress_tracker)
+            .empty()
+    );
 }
 
 TEST_F(
@@ -764,7 +815,8 @@ TEST_F(MagicIdentifyDirectoryTest, valid_magic_empty_path_with_null_tracker)
 TEST_F(MagicIdentifyDirectoryTest, valid_magic_empty_path_with_tracker)
 {
     EXPECT_THROW(
-        static_cast<void>(m_valid_magic.IdentifyFiles(m_empty_path, m_progress_tracker)
+        static_cast<void>(
+            m_valid_magic.IdentifyFiles(m_empty_path, m_progress_tracker)
         ),
         EmptyPath
     );
@@ -773,7 +825,8 @@ TEST_F(MagicIdentifyDirectoryTest, valid_magic_empty_path_with_tracker)
 
 TEST_F(MagicIdentifyDirectoryTest, valid_magic_empty_path_noexcept)
 {
-    EXPECT_TRUE(m_valid_magic.IdentifyFiles(m_empty_path, std::nothrow).empty()
+    EXPECT_TRUE(
+        m_valid_magic.IdentifyFiles(m_empty_path, std::nothrow).empty()
     );
 }
 
@@ -782,19 +835,20 @@ TEST_F(
     valid_magic_empty_path_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(m_valid_magic
-                    .IdentifyFiles(m_empty_path, std::nothrow, m_null_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_valid_magic
+            .IdentifyFiles(m_empty_path, std::nothrow, m_null_progress_tracker)
+            .empty()
+    );
 }
 
-TEST_F(
-    MagicIdentifyDirectoryTest,
-    valid_magic_empty_path_noexcept_with_tracker
-)
+TEST_F(MagicIdentifyDirectoryTest, valid_magic_empty_path_noexcept_with_tracker)
 {
-    EXPECT_TRUE(m_valid_magic
-                    .IdentifyFiles(m_empty_path, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_valid_magic
+            .IdentifyFiles(m_empty_path, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -812,9 +866,10 @@ TEST_F(
 )
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_valid_magic.IdentifyFiles(m_nonexistent_path, m_null_progress_tracker)
-        ),
+        static_cast<void>(m_valid_magic.IdentifyFiles(
+            m_nonexistent_path,
+            m_null_progress_tracker
+        )),
         PathDoesNotExist
     );
 }
@@ -842,11 +897,13 @@ TEST_F(
     valid_magic_nonexistent_path_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(
-        m_valid_magic
-            .IdentifyFiles(m_nonexistent_path, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_valid_magic
+                    .IdentifyFiles(
+                        m_nonexistent_path,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(
@@ -854,9 +911,11 @@ TEST_F(
     valid_magic_nonexistent_path_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_valid_magic
-                    .IdentifyFiles(m_nonexistent_path, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_valid_magic
+            .IdentifyFiles(m_nonexistent_path, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -871,9 +930,10 @@ TEST_F(MagicIdentifyDirectoryTest, valid_magic_file)
 TEST_F(MagicIdentifyDirectoryTest, valid_magic_file_with_null_tracker)
 {
     EXPECT_THROW(
-        static_cast<void>(
-            m_valid_magic.IdentifyFiles(m_valid_database, m_null_progress_tracker)
-        ),
+        static_cast<void>(m_valid_magic.IdentifyFiles(
+            m_valid_database,
+            m_null_progress_tracker
+        )),
         PathIsNotDirectory
     );
 }
@@ -896,23 +956,24 @@ TEST_F(MagicIdentifyDirectoryTest, valid_magic_file_noexcept)
     );
 }
 
-TEST_F(
-    MagicIdentifyDirectoryTest,
-    valid_magic_file_noexcept_with_null_tracker
-)
+TEST_F(MagicIdentifyDirectoryTest, valid_magic_file_noexcept_with_null_tracker)
 {
-    EXPECT_TRUE(
-        m_valid_magic
-            .IdentifyFiles(m_valid_database, std::nothrow, m_null_progress_tracker)
-            .empty()
-    );
+    EXPECT_TRUE(m_valid_magic
+                    .IdentifyFiles(
+                        m_valid_database,
+                        std::nothrow,
+                        m_null_progress_tracker
+                    )
+                    .empty());
 }
 
 TEST_F(MagicIdentifyDirectoryTest, valid_magic_file_noexcept_with_tracker)
 {
-    EXPECT_TRUE(m_valid_magic
-                    .IdentifyFiles(m_valid_database, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_valid_magic
+            .IdentifyFiles(m_valid_database, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -936,14 +997,15 @@ TEST_F(
 
 TEST_F(MagicIdentifyDirectoryTest, valid_magic_empty_directory_with_tracker)
 {
-    EXPECT_TRUE(m_valid_magic.IdentifyFiles(m_empty_dir, m_progress_tracker).empty());
+    EXPECT_TRUE(
+        m_valid_magic.IdentifyFiles(m_empty_dir, m_progress_tracker).empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
 TEST_F(MagicIdentifyDirectoryTest, valid_magic_empty_directory_noexcept)
 {
-    EXPECT_TRUE(m_valid_magic.IdentifyFiles(m_empty_dir, std::nothrow).empty()
-    );
+    EXPECT_TRUE(m_valid_magic.IdentifyFiles(m_empty_dir, std::nothrow).empty());
 }
 
 TEST_F(
@@ -951,9 +1013,11 @@ TEST_F(
     valid_magic_empty_directory_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(m_valid_magic
-                    .IdentifyFiles(m_empty_dir, std::nothrow, m_null_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_valid_magic
+            .IdentifyFiles(m_empty_dir, std::nothrow, m_null_progress_tracker)
+            .empty()
+    );
 }
 
 TEST_F(
@@ -961,9 +1025,11 @@ TEST_F(
     valid_magic_empty_directory_noexcept_with_tracker
 )
 {
-    EXPECT_TRUE(m_valid_magic
-                    .IdentifyFiles(m_empty_dir, std::nothrow, m_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_valid_magic
+            .IdentifyFiles(m_empty_dir, std::nothrow, m_progress_tracker)
+            .empty()
+    );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());
 }
 
@@ -1007,9 +1073,11 @@ TEST_F(
     valid_magic_valid_directory_noexcept_with_null_tracker
 )
 {
-    EXPECT_TRUE(m_valid_magic
-                    .IdentifyFiles(m_test_dir, std::nothrow, m_null_progress_tracker)
-                    .empty());
+    EXPECT_TRUE(
+        m_valid_magic
+            .IdentifyFiles(m_test_dir, std::nothrow, m_null_progress_tracker)
+            .empty()
+    );
 }
 
 TEST_F(
@@ -1018,7 +1086,11 @@ TEST_F(
 )
 {
     EXPECT_EQ(
-        m_valid_magic.IdentifyFiles(m_test_dir, std::nothrow, m_progress_tracker),
+        m_valid_magic.IdentifyFiles(
+            m_test_dir,
+            std::nothrow,
+            m_progress_tracker
+        ),
         m_expected_types_of_valid_files
     );
     EXPECT_TRUE(m_progress_tracker->IsCompleted());

--- a/tests/magic_identify_file_test.cpp
+++ b/tests/magic_identify_file_test.cpp
@@ -32,8 +32,10 @@ struct MagicIdentifyFileTest : testing::Test {
 protected:
     MagicIdentifyFileTest()
     {
-        EXPECT_TRUE(m_opened_magic_without_database
-                        .Open(Magic::Flags::Mime, std::nothrow));
+        EXPECT_TRUE(m_opened_magic_without_database.Open(
+            Magic::Flags::Mime,
+            std::nothrow
+        ));
         EXPECT_FALSE(m_opened_magic_without_database.IsDatabaseLoaded());
         EXPECT_TRUE(m_valid_magic.IsValid());
         std::filesystem::create_directory(m_test_dir, m_error_code);
@@ -116,14 +118,10 @@ TEST_F(MagicIdentifyFileTest, opened_magic_without_database_empty_path)
     );
 }
 
-TEST_F(
-    MagicIdentifyFileTest,
-    opened_magic_without_database_empty_path_noexcept
-)
+TEST_F(MagicIdentifyFileTest, opened_magic_without_database_empty_path_noexcept)
 {
     EXPECT_EQ(
-        m_opened_magic_without_database
-            .IdentifyFile(m_empty_path, std::nothrow)
+        m_opened_magic_without_database.IdentifyFile(m_empty_path, std::nothrow)
             .error(),
         MagicDatabaseNotLoaded{}.what()
     );

--- a/tests/magic_load_database_file_test.cpp
+++ b/tests/magic_load_database_file_test.cpp
@@ -44,8 +44,10 @@ struct MagicLoadDatabaseFileTest : testing::Test {
 protected:
     MagicLoadDatabaseFileTest()
     {
-        EXPECT_TRUE(m_opened_magic_without_database
-                        .Open(Magic::Flags::Mime, std::nothrow));
+        EXPECT_TRUE(m_opened_magic_without_database.Open(
+            Magic::Flags::Mime,
+            std::nothrow
+        ));
         EXPECT_FALSE(m_opened_magic_without_database.IsDatabaseLoaded());
         std::filesystem::create_directory(m_test_dir, m_error_code);
         EXPECT_TRUE(std::filesystem::exists(m_test_dir, m_error_code));
@@ -94,10 +96,7 @@ TEST_F(MagicLoadDatabaseFileTest, closed_magic_noexcept)
     EXPECT_FALSE(m_closed_magic);
 }
 
-TEST_F(
-    MagicLoadDatabaseFileTest,
-    opened_magic_without_database_load_empty_path
-)
+TEST_F(MagicLoadDatabaseFileTest, opened_magic_without_database_load_empty_path)
 {
     EXPECT_THROW(
         m_opened_magic_without_database.LoadDatabaseFile(m_empty_path),
@@ -110,8 +109,10 @@ TEST_F(
     opened_magic_without_database_load_empty_path_noexcept
 )
 {
-    EXPECT_FALSE(m_opened_magic_without_database
-                     .LoadDatabaseFile(std::nothrow, m_empty_path));
+    EXPECT_FALSE(m_opened_magic_without_database.LoadDatabaseFile(
+        std::nothrow,
+        m_empty_path
+    ));
     EXPECT_FALSE(m_opened_magic_without_database.IsDatabaseLoaded());
     EXPECT_FALSE(m_opened_magic_without_database.IsValid());
     EXPECT_FALSE(m_opened_magic_without_database);
@@ -135,17 +136,16 @@ TEST_F(
     opened_magic_without_database_load_nonexistent_database_noexcept
 )
 {
-    EXPECT_FALSE(m_opened_magic_without_database
-                     .LoadDatabaseFile(std::nothrow, m_nonexistent_database));
+    EXPECT_FALSE(m_opened_magic_without_database.LoadDatabaseFile(
+        std::nothrow,
+        m_nonexistent_database
+    ));
     EXPECT_FALSE(m_opened_magic_without_database.IsDatabaseLoaded());
     EXPECT_FALSE(m_opened_magic_without_database.IsValid());
     EXPECT_FALSE(m_opened_magic_without_database);
 }
 
-TEST_F(
-    MagicLoadDatabaseFileTest,
-    opened_magic_without_database_load_directory
-)
+TEST_F(MagicLoadDatabaseFileTest, opened_magic_without_database_load_directory)
 {
     EXPECT_THROW(
         m_opened_magic_without_database.LoadDatabaseFile(m_test_dir),
@@ -158,8 +158,10 @@ TEST_F(
     opened_magic_without_database_load_directory_noexcept
 )
 {
-    EXPECT_FALSE(m_opened_magic_without_database
-                     .LoadDatabaseFile(std::nothrow, m_test_dir));
+    EXPECT_FALSE(m_opened_magic_without_database.LoadDatabaseFile(
+        std::nothrow,
+        m_test_dir
+    ));
     EXPECT_FALSE(m_opened_magic_without_database.IsDatabaseLoaded());
     EXPECT_FALSE(m_opened_magic_without_database.IsValid());
     EXPECT_FALSE(m_opened_magic_without_database);
@@ -181,8 +183,10 @@ TEST_F(
     opened_magic_without_database_load_invalid_database_noexcept
 )
 {
-    EXPECT_FALSE(m_opened_magic_without_database
-                     .LoadDatabaseFile(std::nothrow, m_invalid_database));
+    EXPECT_FALSE(m_opened_magic_without_database.LoadDatabaseFile(
+        std::nothrow,
+        m_invalid_database
+    ));
     EXPECT_FALSE(m_opened_magic_without_database.IsDatabaseLoaded());
     EXPECT_FALSE(m_opened_magic_without_database.IsValid());
     EXPECT_FALSE(m_opened_magic_without_database);
@@ -204,8 +208,10 @@ TEST_F(
     opened_magic_without_database_load_valid_database_noexcept
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .LoadDatabaseFile(std::nothrow, m_valid_database));
+    EXPECT_TRUE(m_opened_magic_without_database.LoadDatabaseFile(
+        std::nothrow,
+        m_valid_database
+    ));
     EXPECT_TRUE(m_opened_magic_without_database.IsDatabaseLoaded());
     EXPECT_TRUE(m_opened_magic_without_database.IsValid());
     EXPECT_TRUE(m_opened_magic_without_database);
@@ -213,26 +219,34 @@ TEST_F(
 
 TEST_F(MagicLoadDatabaseFileTest, load_database_files_multiple_times)
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .LoadDatabaseFile(std::nothrow, m_valid_database));
+    EXPECT_TRUE(m_opened_magic_without_database.LoadDatabaseFile(
+        std::nothrow,
+        m_valid_database
+    ));
     EXPECT_TRUE(m_opened_magic_without_database.IsDatabaseLoaded());
     EXPECT_TRUE(m_opened_magic_without_database.IsValid());
     EXPECT_TRUE(m_opened_magic_without_database);
 
-    EXPECT_FALSE(m_opened_magic_without_database
-                     .LoadDatabaseFile(std::nothrow, m_invalid_database));
+    EXPECT_FALSE(m_opened_magic_without_database.LoadDatabaseFile(
+        std::nothrow,
+        m_invalid_database
+    ));
     EXPECT_FALSE(m_opened_magic_without_database.IsDatabaseLoaded());
     EXPECT_FALSE(m_opened_magic_without_database.IsValid());
     EXPECT_FALSE(m_opened_magic_without_database);
 
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .LoadDatabaseFile(std::nothrow, m_valid_database));
+    EXPECT_TRUE(m_opened_magic_without_database.LoadDatabaseFile(
+        std::nothrow,
+        m_valid_database
+    ));
     EXPECT_TRUE(m_opened_magic_without_database.IsDatabaseLoaded());
     EXPECT_TRUE(m_opened_magic_without_database.IsValid());
     EXPECT_TRUE(m_opened_magic_without_database);
 
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .LoadDatabaseFile(std::nothrow, m_valid_database));
+    EXPECT_TRUE(m_opened_magic_without_database.LoadDatabaseFile(
+        std::nothrow,
+        m_valid_database
+    ));
     EXPECT_TRUE(m_opened_magic_without_database.IsDatabaseLoaded());
     EXPECT_TRUE(m_opened_magic_without_database.IsValid());
     EXPECT_TRUE(m_opened_magic_without_database);

--- a/tests/magic_open_close_test.cpp
+++ b/tests/magic_open_close_test.cpp
@@ -62,12 +62,9 @@ protected:
             static_cast<Magic::Flags>(1ULL << m_dist(m_eng)),
             static_cast<Magic::Flags>(1ULL << m_dist(m_eng))
         };
-        std::ranges::sort(
-            test_flags,
-            [](Magic::Flags a, Magic::Flags b) {
-                return std::to_underlying(a) < std::to_underlying(b);
-            }
-        );
+        std::ranges::sort(test_flags, [](Magic::Flags a, Magic::Flags b) {
+            return std::to_underlying(a) < std::to_underlying(b);
+        });
         m_test_flags_container.clear();
         m_test_flags_container.assign(test_flags.begin(), test_flags.end());
         m_test_flags_container.erase(
@@ -80,14 +77,16 @@ protected:
         m_test_flags_mask = std::ranges::fold_left(
             m_test_flags_container,
             Magic::FlagsMaskT{},
-            [](Magic::FlagsMaskT acc, Magic::Flags f) { return acc | f; }
+            [](Magic::FlagsMaskT acc, Magic::Flags f) {
+                return acc | f;
+            }
         );
     }
 
-    std::filesystem::path    m_valid_database{MAGIC_DEFAULT_DATABASE_FILE};
+    std::filesystem::path  m_valid_database{MAGIC_DEFAULT_DATABASE_FILE};
     Magic::FlagsContainerT m_test_flags_container{};
     Magic::FlagsMaskT      m_test_flags_mask{};
-    std::mt19937             m_eng{std::random_device{}()};
+    std::mt19937           m_eng{std::random_device{}()};
     std::uniform_int_distribution<std::size_t> m_dist{
         0,
         Magic::FlagsMaskT{}.size() - 1

--- a/tests/magic_parameters_test.cpp
+++ b/tests/magic_parameters_test.cpp
@@ -42,8 +42,10 @@ struct MagicParametersTest : testing::Test {
 protected:
     MagicParametersTest()
     {
-        EXPECT_TRUE(m_opened_magic_without_database
-                        .Open(Magic::Flags::Mime, std::nothrow));
+        EXPECT_TRUE(m_opened_magic_without_database.Open(
+            Magic::Flags::Mime,
+            std::nothrow
+        ));
         EXPECT_TRUE(m_valid_magic.IsValid());
         std::error_code error_code;
         EXPECT_TRUE(std::filesystem::exists(m_valid_database, error_code));
@@ -53,14 +55,14 @@ protected:
     {
         using enum Magic::Parameters;
         m_test_parameters = {
-            {IndirMax,      m_distribution(m_engine)},
-            {NameMax,       m_distribution(m_engine)},
+            {IndirMax,     m_distribution(m_engine)},
+            {NameMax,      m_distribution(m_engine)},
             {ElfPhnumMax,  m_distribution(m_engine)},
             {ElfShnumMax,  m_distribution(m_engine)},
             {ElfNotesMax,  m_distribution(m_engine)},
-            {RegexMax,      m_distribution(m_engine)},
-            {BytesMax,      m_distribution(m_engine)},
-            {EncodingMax,   m_distribution(m_engine)},
+            {RegexMax,     m_distribution(m_engine)},
+            {BytesMax,     m_distribution(m_engine)},
+            {EncodingMax,  m_distribution(m_engine)},
             {ElfShsizeMax, m_distribution(m_engine)},
             {MagWarnMax,   m_distribution(m_engine)}
         };
@@ -70,7 +72,7 @@ protected:
     Magic                 m_closed_magic{};
     Magic                 m_opened_magic_without_database;
     Magic m_valid_magic{Magic::Flags::Mime, std::nothrow, m_valid_database};
-    Magic::ParameterValueMapT               m_test_parameters{};
+    Magic::ParameterValueMapT                  m_test_parameters{};
     std::mt19937                               m_engine{std::random_device{}()};
     std::uniform_int_distribution<std::size_t> m_distribution{0, 100};
 };
@@ -106,8 +108,7 @@ TEST_F(MagicParametersTest, closed_magic_set_parameters)
 
 TEST_F(MagicParametersTest, closed_magic_set_parameters_noexcept)
 {
-    EXPECT_FALSE(m_closed_magic.SetParameters(m_test_parameters, std::nothrow)
-    );
+    EXPECT_FALSE(m_closed_magic.SetParameters(m_test_parameters, std::nothrow));
 }
 
 TEST_F(MagicParametersTest, closed_magic_get_parameters)
@@ -143,13 +144,17 @@ TEST_F(
 )
 {
     for (const auto& [parameter, parameter_value] : m_test_parameters) {
-        EXPECT_TRUE(m_opened_magic_without_database
-                        .SetParameter(parameter, parameter_value, std::nothrow)
-        );
+        EXPECT_TRUE(m_opened_magic_without_database.SetParameter(
+            parameter,
+            parameter_value,
+            std::nothrow
+        ));
         EXPECT_EQ(
             parameter_value,
-            m_opened_magic_without_database
-                .GetParameter(parameter, std::nothrow)
+            m_opened_magic_without_database.GetParameter(
+                parameter,
+                std::nothrow
+            )
         );
     }
 }
@@ -168,8 +173,10 @@ TEST_F(
     opened_magic_without_database_set_parameters_noexcept
 )
 {
-    EXPECT_TRUE(m_opened_magic_without_database
-                    .SetParameters(m_test_parameters, std::nothrow));
+    EXPECT_TRUE(m_opened_magic_without_database.SetParameters(
+        m_test_parameters,
+        std::nothrow
+    ));
     EXPECT_EQ(
         m_test_parameters,
         m_opened_magic_without_database.GetParameters(std::nothrow)
@@ -187,8 +194,8 @@ TEST_F(MagicParametersTest, valid_magic_set_parameter)
 TEST_F(MagicParametersTest, valid_magic_set_parameter_noexcept)
 {
     for (const auto& [parameter, parameter_value] : m_test_parameters) {
-        EXPECT_TRUE(m_valid_magic
-                        .SetParameter(parameter, parameter_value, std::nothrow)
+        EXPECT_TRUE(
+            m_valid_magic.SetParameter(parameter, parameter_value, std::nothrow)
         );
         EXPECT_EQ(
             parameter_value,

--- a/tests/magic_progress_tracker_test.cpp
+++ b/tests/magic_progress_tracker_test.cpp
@@ -189,13 +189,15 @@ TEST(MagicProgressTrackerTest, reset_step_count_multiple_times)
 TEST(MagicProgressTrackerTest, thread_safety)
 {
     ProgressTracker progress_tracker{100};
-    constexpr auto number_of_threads = 10;
-    constexpr auto steps_per_thread = 10;
+    constexpr auto  number_of_threads = 10;
+    constexpr auto  steps_per_thread  = 10;
 
     std::vector<std::thread> threads;
-    for (int thread_index = 0; thread_index < number_of_threads; ++thread_index) {
+    for (int thread_index = 0; thread_index < number_of_threads;
+         ++thread_index) {
         threads.emplace_back([&progress_tracker]() {
-            for (int step_index = 0; step_index < steps_per_thread; ++step_index) {
+            for (int step_index = 0; step_index < steps_per_thread;
+                 ++step_index) {
                 progress_tracker.Advance();
             }
         });

--- a/tests/magic_special_members_test.cpp
+++ b/tests/magic_special_members_test.cpp
@@ -124,10 +124,7 @@ TEST_F(
 
 TEST_F(MagicSpecialMembersTest, construct_magic_from_directory)
 {
-    EXPECT_THROW(
-        Magic(Magic::Flags::Mime, m_test_dir),
-        PathIsNotRegularFile
-    );
+    EXPECT_THROW(Magic(Magic::Flags::Mime, m_test_dir), PathIsNotRegularFile);
 }
 
 TEST_F(MagicSpecialMembersTest, construct_magic_from_directory_noexcept)
@@ -151,10 +148,7 @@ TEST_F(MagicSpecialMembersTest, construct_magic_from_invalid_database)
     );
 }
 
-TEST_F(
-    MagicSpecialMembersTest,
-    construct_magic_from_invalid_database_noexcept
-)
+TEST_F(MagicSpecialMembersTest, construct_magic_from_invalid_database_noexcept)
 {
     Magic opened_magic_without_database{
         Magic::Flags::Mime,

--- a/tests/magic_to_string_test.cpp
+++ b/tests/magic_to_string_test.cpp
@@ -46,11 +46,13 @@ TEST(MagicToStringTest, file_type_entry_t)
 TEST(MagicToStringTest, file_type_map_t)
 {
     EXPECT_EQ(
-        ToString(Magic::FileTypeMapT{
-            {"path1", "type1"},
-            {"path2", "type2"},
-            {"path3", "type3"}
-    }),
+        ToString(
+            Magic::FileTypeMapT{
+                {"path1", "type1"},
+                {"path2", "type2"},
+                {"path3", "type3"}
+    }
+        ),
         "path1 -> type1\n"
         "path2 -> type2\n"
         "path3 -> type3"
@@ -74,11 +76,13 @@ TEST(MagicToStringTest, expected_file_type_entry_t)
 TEST(MagicToStringTest, expected_file_type_map_t)
 {
     EXPECT_EQ(
-        ToString(Magic::ExpectedFileTypeMapT{
-            {"path1", "type1"                  },
-            {"path2", std::unexpected{"error1"}},
-            {"path3", "type2"                  }
-    }),
+        ToString(
+            Magic::ExpectedFileTypeMapT{
+                {"path1", "type1"                  },
+                {"path2", std::unexpected{"error1"}},
+                {"path3", "type2"                  }
+    }
+        ),
         "path1 -> type1\n"
         "path2 -> error1\n"
         "path3 -> type2"
@@ -125,39 +129,41 @@ TEST(MagicToStringTest, flags_container_t)
 {
     using enum Magic::Flags;
     EXPECT_EQ(
-        ToString(Magic::FlagsContainerT{
-            None,
-            Debug,
-            Symlink,
-            Compress,
-            Devices,
-            MimeType,
-            ContinueSearch,
-            CheckDatabase,
-            PreserveAtime,
-            Raw,
-            Error,
-            MimeEncoding,
-            Mime,
-            Apple,
-            Extension,
-            CompressTransp,
-            NoCompressFork,
-            Nodesc,
-            NoCheckCompress,
-            NoCheckTar,
-            NoCheckSoft,
-            NoCheckApptype,
-            NoCheckElf,
-            NoCheckText,
-            NoCheckCdf,
-            NoCheckCsv,
-            NoCheckTokens,
-            NoCheckEncoding,
-            NoCheckJson,
-            NoCheckSimh,
-            NoCheckBuiltin
-        }),
+        ToString(
+            Magic::FlagsContainerT{
+                None,
+                Debug,
+                Symlink,
+                Compress,
+                Devices,
+                MimeType,
+                ContinueSearch,
+                CheckDatabase,
+                PreserveAtime,
+                Raw,
+                Error,
+                MimeEncoding,
+                Mime,
+                Apple,
+                Extension,
+                CompressTransp,
+                NoCompressFork,
+                Nodesc,
+                NoCheckCompress,
+                NoCheckTar,
+                NoCheckSoft,
+                NoCheckApptype,
+                NoCheckElf,
+                NoCheckText,
+                NoCheckCdf,
+                NoCheckCsv,
+                NoCheckTokens,
+                NoCheckEncoding,
+                NoCheckJson,
+                NoCheckSimh,
+                NoCheckBuiltin
+            }
+        ),
         "None, "
         "Debug, "
         "Symlink, "
@@ -210,28 +216,27 @@ TEST(MagicToStringTest, parameters)
 TEST(MagicToStringTest, parameter_value_t)
 {
     using enum Magic::Parameters;
-    EXPECT_EQ(
-        ToString(Magic::ParameterValueT{IndirMax, 1}),
-        "IndirMax: 1"
-    );
+    EXPECT_EQ(ToString(Magic::ParameterValueT{IndirMax, 1}), "IndirMax: 1");
 }
 
 TEST(MagicToStringTest, parameter_value_map_t)
 {
     using enum Magic::Parameters;
     EXPECT_EQ(
-        ToString(Magic::ParameterValueMapT{
-            {IndirMax,      1 },
-            {NameMax,       2 },
-            {ElfPhnumMax,   3 },
-            {ElfShnumMax,   4 },
-            {ElfNotesMax,   5 },
-            {RegexMax,      6 },
-            {BytesMax,      7 },
-            {EncodingMax,   8 },
-            {ElfShsizeMax,  9 },
-            {MagWarnMax,    10}
-    }),
+        ToString(
+            Magic::ParameterValueMapT{
+                {IndirMax,     1 },
+                {NameMax,      2 },
+                {ElfPhnumMax,  3 },
+                {ElfShnumMax,  4 },
+                {ElfNotesMax,  5 },
+                {RegexMax,     6 },
+                {BytesMax,     7 },
+                {EncodingMax,  8 },
+                {ElfShsizeMax, 9 },
+                {MagWarnMax,   10}
+    }
+        ),
         "IndirMax: 1, "
         "NameMax: 2, "
         "ElfPhnumMax: 3, "


### PR DESCRIPTION
# Pull Request Template

## Description

CMake, Format: Include example and test files in format and lint targets.

Fixes issue #203.

...

## Checklist

- [x] Branch created from `main` (or release branch for bugfix)
- [x] Code follows <a href="STYLE_GUIDE.md">STYLE_GUIDE.md</a>
- [x] Clang tests pass: `./scripts/workflows.sh -p linux-x86_64-clang-tests -c`
- [x] GCC tests pass: `./scripts/workflows.sh -p linux-x86_64-gcc-tests -c`
- [x] Code formatted: `./scripts/workflows.sh -p format-source-code`
- [x] Clang-tidy checks pass: `./scripts/workflows.sh -p clang-tidy-checks -c`
- [x] Documentation generates cleanly: `./scripts/workflows.sh -p documentation`
- [x] New tests added for new functionality
- [x] Doxygen comments added for new public APIs
- [x] CHANGELOG.md updated
- [x] Linked to an existing issue (or created one)

### Title Format Guidelines

+ For bug fixes: `[BUGFIX] Brief Description, Fixes issue #????.`
+ For documentation changes: `[DOCUMENTATION] Brief Description, Fixes issue #????.`
+ For enhancements: `[ENHANCEMENT] Brief Description, Fixes issue #????.`
+ For code quality improvements: `[QUALITY] Brief Description, Fixes issue #????.`
