### PR TITLE
[ENHANCEMENT] Magic: Bump libmagic version to 5.47, Fixes issue #211.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ **[BUGFIX]** Magic: Add -B flag to make command for rebuilding magic.h.
+
 + **[DOCUMENTATION]** Docs: Update documentation guidelines for Doxygen comments and CHANGELOG entries.
 
 + **[DOCUMENTATION]** Docs: Consolidate agent guidance into .github/copilot-instructions.md by removing AGENTS.md and introduce C++ Expert agent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ **[ENHANCEMENT]** Magic: Bump libmagic version to 5.47 and update related tests.
+
 + **[BUGFIX]** Magic: Add -B flag to make command for rebuilding magic.h.
 
 + **[DOCUMENTATION]** Docs: Update documentation guidelines for Doxygen comments and CHANGELOG entries.

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -40,7 +40,7 @@ add_custom_target(configure_file
         --host=${FILE_TARGET}
         --silent
     COMMAND
-        make -C ${magic_SOURCE_DIR} magic.h
+        make -C ${magic_SOURCE_DIR} -B magic.h
     WORKING_DIRECTORY
         ${magic_DIR}
     COMMENT

--- a/databases/magic
+++ b/databases/magic
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea2816afb21e1131cd8497528f7d2b6aeec389dd34ff45104d113d5bb09b6311
-size 1826143
+oid sha256:c0c02d3193b02564f0d3da85b0ef66ecf5f795a7cca477fbf34c659ea6cb3cd7
+size 1862668

--- a/databases/magic.mgc
+++ b/databases/magic.mgc
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a2f5cfb36910f30a9722d5adbddfdeeadba2d38ee128d29e8363a79e48248454
-size 10355472
+oid sha256:ca0d3f3bf83c2db30b163e9138bcce31f306ffc34c3ff4482b0bdf213f879281
+size 10658304

--- a/tests/magic_version_test.cpp
+++ b/tests/magic_version_test.cpp
@@ -15,7 +15,7 @@
  * - The returned version matches the expected libmagic version
  * - The version format is a valid version string
  *
- * @note The expected version ("5.46") corresponds to the bundled
+ * @note The expected version ("5.47") corresponds to the bundled
  *       libmagic version in the external/file submodule.
  *
  * @see Magic::GetVersion()
@@ -29,5 +29,5 @@ using namespace Recognition;
 
 TEST(MagicVersionTest, magic_get_version)
 {
-    EXPECT_EQ(Magic::GetVersion(), "5.46");
+    EXPECT_EQ(Magic::GetVersion(), "5.47");
 }

--- a/tests/magic_version_test.cpp
+++ b/tests/magic_version_test.cpp
@@ -12,8 +12,7 @@
  *
  * This test verifies that:
  * - GetVersion() is callable as a static method
- * - The returned version matches the expected libmagic version
- * - The version format is a valid version string
+ * - The returned version matches the expected bundled libmagic version
  *
  * @note The expected version ("5.47") corresponds to the bundled
  *       libmagic version in the external/file submodule.


### PR DESCRIPTION
# Pull Request Template

## Description

Magic: Bump libmagic version to 5.47 and update related tests.

Magic: Add -B flag to make command for rebuilding magic.h.

Fixes issue #211.

...

## Checklist

- [x] Branch created from `main` (or release branch for bugfix)
- [x] Code follows <a href="STYLE_GUIDE.md">STYLE_GUIDE.md</a>
- [x] Clang tests pass: `./scripts/workflows.sh -p linux-x86_64-clang-tests -c`
- [x] GCC tests pass: `./scripts/workflows.sh -p linux-x86_64-gcc-tests -c`
- [x] Code formatted: `./scripts/workflows.sh -p format-source-code`
- [x] Clang-tidy checks pass: `./scripts/workflows.sh -p clang-tidy-checks -c`
- [x] Documentation generates cleanly: `./scripts/workflows.sh -p documentation`
- [x] New tests added for new functionality
- [x] Doxygen comments updated for all changed functions/symbols (public and internal)
- [x] CHANGELOG.md updated and includes the exact commit subject line(s) prefixed with exactly one of: `[DOCUMENTATION]`, `[BUGFIX]`, `[ENHANCEMENT]`, `[QUALITY]`
- [x] All code changes (internal and public API) include documentation updates
- [x] Linked to an existing issue (or created one)

### Title Format Guidelines

+ For bug fixes: `[BUGFIX] Brief Description, Fixes issue #????.`
+ For documentation changes: `[DOCUMENTATION] Brief Description, Fixes issue #????.`
+ For enhancements: `[ENHANCEMENT] Brief Description, Fixes issue #????.`
+ For code quality improvements: `[QUALITY] Brief Description, Fixes issue #????.`
