### PR TITLE
[QUALITY] Format: Disable short case expressions and labels on a single line, Fixes issue #218.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,8 +26,8 @@ AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowBreakBeforeNoexceptSpecifier: OnlyWithParen
 AllowShortBlocksOnASingleLine: false
-AllowShortCaseExpressionOnASingleLine: true
-AllowShortCaseLabelsOnASingleLine: true
+AllowShortCaseExpressionOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
 AllowShortCompoundRequirementOnASingleLine: false
 AllowShortEnumsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next Release
 
++ **[QUALITY]** Format: Disable short case expressions and labels on a single line.
+
 + **[ENHANCEMENT]** CMake: Add ccache as compiler launcher in base-config preset to speed up compilation.
 
 + **[ENHANCEMENT]** DevEnv: Install ccache in the development container.


### PR DESCRIPTION
# Pull Request Template

## Description

Format: Disable short case expressions and labels on a single line.

Fixes issue #218.

...

## Checklist

- [x] Branch created from `main` (or release branch for bugfix)
- [x] Code follows <a href="STYLE_GUIDE.md">STYLE_GUIDE.md</a>
- [x] Clang tests pass: `./scripts/workflows.sh -p linux-x86_64-clang-tests -c`
- [x] GCC tests pass: `./scripts/workflows.sh -p linux-x86_64-gcc-tests -c`
- [x] Code formatted: `./scripts/workflows.sh -p format-source-code`
- [ ] Clang-tidy checks pass: `./scripts/workflows.sh -p clang-tidy-checks -c`
- [x] Documentation generates cleanly: `./scripts/workflows.sh -p documentation`
- [x] New tests added for new functionality
- [x] Doxygen comments updated for all changed functions/symbols (public and internal)
- [x] CHANGELOG.md updated and includes the exact commit subject line(s) prefixed with exactly one of: `[DOCUMENTATION]`, `[BUGFIX]`, `[ENHANCEMENT]`, `[QUALITY]`
- [x] All code changes (internal and public API) include documentation updates
- [x] Linked to an existing issue (or created one)

### Title Format Guidelines

+ For bug fixes: `[BUGFIX] Brief Description, Fixes issue #????.`
+ For documentation changes: `[DOCUMENTATION] Brief Description, Fixes issue #????.`
+ For enhancements: `[ENHANCEMENT] Brief Description, Fixes issue #????.`
+ For code quality improvements: `[QUALITY] Brief Description, Fixes issue #????.`
